### PR TITLE
fix: Solve a few issues with the Create Snapshot button

### DIFF
--- a/src/app/backups/[id]/CreateSnapshotButton.tsx
+++ b/src/app/backups/[id]/CreateSnapshotButton.tsx
@@ -1,21 +1,17 @@
 'use client'
 
 import { Backup } from '@/app/types'
-import { Button } from '@/components/ui'
 import { useAuthenticator } from '@storacha/ui-react'
 import { createSnapshot } from './createSnapshot'
 import { delegate } from './delegate'
 import { useSWRMutation } from '@/app/swr'
+import { CreateButton } from '@/components/ui/CreateButton'
 
-export const CreateSnapshotButton = ({
-  backup,
-}: {
-  backup: Backup | undefined
-}) => {
+export const CreateSnapshotButton = ({ backup }: { backup: Backup }) => {
   const [{ accounts, client }] = useAuthenticator()
   const account = accounts[0]
 
-  const enabled = backup && client
+  const enabled = client && backup
 
   const { trigger } = useSWRMutation(
     enabled && ['api', `/api/backups/${backup.id}/snapshots`],
@@ -33,24 +29,15 @@ export const CreateSnapshotButton = ({
   }
 
   return (
-    <Button
-      $background={
-        enabled ? 'var(--color-dark-blue)' : 'var(--color-gray-medium)'
-      }
-      $color="var(--color-white)"
-      $textTransform="capitalize"
-      $width="fit-content"
-      $fontSize="0.75rem"
-      $mt="1.4rem"
+    <CreateButton
       onClick={
         enabled &&
         (() => {
           trigger()
         })
       }
-      disabled={!enabled}
     >
       create snapshot
-    </Button>
+    </CreateButton>
   )
 }

--- a/src/app/backups/[id]/CreateSnapshotButton.tsx
+++ b/src/app/backups/[id]/CreateSnapshotButton.tsx
@@ -10,7 +10,7 @@ export const CreateSnapshotButton = ({
   backup,
   mutateBackups,
 }: {
-  backup: Backup
+  backup: Backup | undefined
   mutateBackups: () => void
 }) => {
   const [{ accounts, client }] = useAuthenticator()
@@ -19,21 +19,26 @@ export const CreateSnapshotButton = ({
     return null
   }
 
-  const handleClick = async () => {
-    const delegationData = await delegate(client, backup.storachaSpace)
-    await createSnapshot({ backupId: backup.id, delegationData })
-    mutateBackups()
-  }
+  const handleClick =
+    backup &&
+    (async () => {
+      const delegationData = await delegate(client, backup.storachaSpace)
+      await createSnapshot({ backupId: backup.id, delegationData })
+      mutateBackups()
+    })
 
   return (
     <Button
-      $background="var(--color-dark-blue)"
+      $background={
+        handleClick ? 'var(--color-dark-blue)' : 'var(--color-gray-medium)'
+      }
       $color="var(--color-white)"
       $textTransform="capitalize"
       $width="fit-content"
       $fontSize="0.75rem"
       $mt="1.4rem"
       onClick={handleClick}
+      disabled={!handleClick}
     >
       create snapshot
     </Button>

--- a/src/app/backups/[id]/CreateSnapshotButton.tsx
+++ b/src/app/backups/[id]/CreateSnapshotButton.tsx
@@ -18,7 +18,7 @@ export const CreateSnapshotButton = ({
   const enabled = backup && client
 
   const { trigger } = useSWRMutation(
-    enabled && ['api', '/api/backups'],
+    enabled && ['api', `/api/backups/${backup.id}/snapshots`],
     async () => {
       // SWR guarantees this won't actually happen.
       if (!enabled)

--- a/src/app/backups/[id]/CreateSnapshotButton.tsx
+++ b/src/app/backups/[id]/CreateSnapshotButton.tsx
@@ -5,40 +5,50 @@ import { Button } from '@/components/ui'
 import { useAuthenticator } from '@storacha/ui-react'
 import { createSnapshot } from './createSnapshot'
 import { delegate } from './delegate'
+import { useSWRMutation } from '@/app/swr'
 
 export const CreateSnapshotButton = ({
   backup,
-  mutateBackups,
 }: {
   backup: Backup | undefined
-  mutateBackups: () => void
 }) => {
   const [{ accounts, client }] = useAuthenticator()
   const account = accounts[0]
+
+  const enabled = backup && client
+
+  const { trigger } = useSWRMutation(
+    enabled && ['api', '/api/backups'],
+    async () => {
+      // SWR guarantees this won't actually happen.
+      if (!enabled)
+        throw new Error('Mutation ran but key should have been null')
+      const delegationData = await delegate(client, backup.storachaSpace)
+      await createSnapshot({ backupId: backup.id, delegationData })
+    }
+  )
+
   if (!account || !client) {
     return null
   }
 
-  const handleClick =
-    backup &&
-    (async () => {
-      const delegationData = await delegate(client, backup.storachaSpace)
-      await createSnapshot({ backupId: backup.id, delegationData })
-      mutateBackups()
-    })
-
   return (
     <Button
       $background={
-        handleClick ? 'var(--color-dark-blue)' : 'var(--color-gray-medium)'
+        enabled ? 'var(--color-dark-blue)' : 'var(--color-gray-medium)'
       }
       $color="var(--color-white)"
       $textTransform="capitalize"
       $width="fit-content"
       $fontSize="0.75rem"
       $mt="1.4rem"
-      onClick={handleClick}
-      disabled={!handleClick}
+      onClick={
+        enabled &&
+        (() => {
+          trigger()
+        })
+      }
+      disabled={!enabled}
     >
       create snapshot
     </Button>

--- a/src/app/swr.tsx
+++ b/src/app/swr.tsx
@@ -3,6 +3,7 @@
 import { Agent } from '@atproto/api'
 import React from 'react'
 import useSWRBase, { SWRConfig, SWRResponse } from 'swr'
+import useSWRMutationBase, { MutationFetcher } from 'swr/mutation'
 import { ATBlob, Snapshot, Backup } from './types'
 
 // This type defines what's fetchable with `useSWR`. It is a union of key/data
@@ -87,12 +88,41 @@ const fetchers: Fetchers = {
   },
 }
 
+/**
+ * Exactly the same as `useSWR`, but typed to only accept the keys supported by
+ * our fetchers and config. Also, logs any errors to the console.
+ */
 export const useSWR = <K extends Key>(
   key: K | null | undefined
 ): SWRResponse<FetchedData<K>> => {
   const swrResponse = useSWRBase(key)
   if (swrResponse.error) {
     console.error('SWR error:', swrResponse.error)
+  }
+  return swrResponse
+}
+
+/**
+ * Exactly the same as `useSWRMutation`, but typed to only accept the keys
+ * supported by our fetchers and config, and the options object is not currently
+ * supported. (It could be, but the types take some effort, and we haven't hit a
+ * use for it so far.) Also, logs any errors to the console.
+ */
+export const useSWRMutation = <
+  Data = unknown,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Matches useSWRMutationBase
+  Error = unknown,
+  SWRMutationKey extends Key = Key,
+  ExtraArg = never,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Matches useSWRMutationBase
+  SWRData = Data,
+>(
+  key: SWRMutationKey | null | undefined,
+  fetcher: MutationFetcher<Data, SWRMutationKey, ExtraArg>
+) => {
+  const swrResponse = useSWRMutationBase(key, fetcher)
+  if (swrResponse.error) {
+    console.error('SWR mutation error:', swrResponse.error)
   }
   return swrResponse
 }

--- a/src/components/Backup/Backup.tsx
+++ b/src/components/Backup/Backup.tsx
@@ -12,6 +12,7 @@ import { CreateSnapshotButton } from '@/app/backups/[id]/CreateSnapshotButton'
 import { PlusCircle } from '@phosphor-icons/react'
 import { useDisclosure } from '@/hooks/use-disclosure'
 import { useUiComponentStore } from '@/store/ui'
+import { CreateButton } from '@/components/ui/CreateButton'
 
 interface BackupProps {
   account?: Account
@@ -215,7 +216,11 @@ export const BackupDetail = ({ account, backup }: BackupProps) => {
               ))}
             </Stack>
           </Stack>
-          <CreateSnapshotButton backup={backup} />
+          {backup ? (
+            <CreateSnapshotButton backup={backup} />
+          ) : (
+            <CreateButton type="submit">create backup</CreateButton>
+          )}
         </Stack>
       </BackupContainer>
 

--- a/src/components/Backup/Backup.tsx
+++ b/src/components/Backup/Backup.tsx
@@ -1,4 +1,4 @@
-import { Button, Modal, Stack, Text } from '../ui'
+import { Modal, Stack, Text } from '../ui'
 import { styled } from 'next-yak'
 import { Property } from 'csstype'
 import { ReactNode, useEffect, useState } from 'react'
@@ -9,7 +9,6 @@ import { Account } from '@storacha/ui-react'
 import { BlueskyAccountSelect } from '@/components/Backup/BlueskyAccountSelect'
 import { StorachaSpaceSelect } from '@/components/Backup/StorachaSpaceSelect'
 import { CreateSnapshotButton } from '@/app/backups/[id]/CreateSnapshotButton'
-import { mutate } from 'swr'
 import { PlusCircle } from '@phosphor-icons/react'
 import { useDisclosure } from '@/hooks/use-disclosure'
 import { useUiComponentStore } from '@/store/ui'
@@ -216,10 +215,7 @@ export const BackupDetail = ({ account, backup }: BackupProps) => {
               ))}
             </Stack>
           </Stack>
-          <CreateSnapshotButton
-            backup={backup}
-            mutateBackups={() => mutate(['api', '/api/backups'])}
-          />
+          <CreateSnapshotButton backup={backup} />
         </Stack>
       </BackupContainer>
 

--- a/src/components/Backup/Backup.tsx
+++ b/src/components/Backup/Backup.tsx
@@ -216,24 +216,10 @@ export const BackupDetail = ({ account, backup }: BackupProps) => {
               ))}
             </Stack>
           </Stack>
-          {backup ? (
-            <CreateSnapshotButton
-              backup={backup}
-              mutateBackups={() => mutate(['api', '/api/backups'])}
-            />
-          ) : (
-            <Button
-              type="submit"
-              $background="var(--color-dark-blue)"
-              $color="var(--color-white)"
-              $textTransform="capitalize"
-              $width="fit-content"
-              $fontSize="0.75rem"
-              $mt="1.4rem"
-            >
-              create backup
-            </Button>
-          )}
+          <CreateSnapshotButton
+            backup={backup}
+            mutateBackups={() => mutate(['api', '/api/backups'])}
+          />
         </Stack>
       </BackupContainer>
 

--- a/src/components/Backup/Restore.tsx
+++ b/src/components/Backup/Restore.tsx
@@ -104,7 +104,7 @@ export const BackupRestore = ({ backup }: BackupRestoreProps) => {
       ) : (
         <Center $height="90vh">
           <Instruction $fontWeight="600">
-            Press &quot;Create Backup&quot; to get started!
+            Press &quot;Create Snapshot&quot; to get started!
           </Instruction>
         </Center>
       )}

--- a/src/components/ui/CreateButton.tsx
+++ b/src/components/ui/CreateButton.tsx
@@ -1,0 +1,33 @@
+import { Button } from '@/components/ui'
+import type React from 'react'
+
+/**
+ * A button that we'd use for creating a new item. This is currently a guess at
+ * its actual scope--the name should evolve as we understan what this form of
+ * button should be used for in the app.
+ */
+export const CreateButton = ({
+  type,
+  onClick,
+  disabled,
+  children,
+}: Pick<
+  React.ComponentProps<typeof Button>,
+  'type' | 'onClick' | 'disabled' | 'children'
+>) => (
+  <Button
+    $background={
+      disabled ? 'var(--color-gray-medium)' : 'var(--color-dark-blue)'
+    }
+    $color="var(--color-white)"
+    $textTransform="capitalize"
+    $width="fit-content"
+    $fontSize="0.75rem"
+    $mt="1.4rem"
+    type={type}
+    onClick={onClick}
+    disabled={disabled}
+  >
+    {children}
+  </Button>
+)


### PR DESCRIPTION
Solves three problems, one commit at a time:

* The styling for the buttons was duplicated; now it's all in one place. I've named the common styling `CreateButton`, but noted that we probably don't know what that style of button actually signifies yet, and the name should evolve.
* A function performing the SWR mutation was being passed into the component, but a server component can't pass a function to a client component, because it can't be serialized. That's okay, though, because the button should really know enough to do the mutation itself, since it also does the actual request. I've done it in a slightly fancy way by using `useSWRMutation`, but it means we get some type safety on the key, just like with `useSWR`.
* The wrong key was being mutated: we want the list of Snapshots, not the list of Backups. I assume this got confused during the rename. 😄 

**To review:** Please try it by hand a few ways to confirm a) it's not broken, and b) it immediately invalidates and refetches the list of snapshots, which we should see it not do before this change. My machine is still having trouble with ngrok, and I haven't been able to test it all the way through. I've had to stub out some things locally to get anything to run. 😕 


#### PR Dependency Tree


* **PR #34** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)