### PR TITLE
fix: put BackupDetail behind Suspense for now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,5 +10,4 @@ jobs:
       - uses: ./.github/actions/pnpm
       - run: pnpm lint
       - run: pnpm test
-      - run: pnpm build
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,3 +10,5 @@ jobs:
       - uses: ./.github/actions/pnpm
       - run: pnpm lint
       - run: pnpm test
+      - run: pnpm build
+

--- a/src/components/Backup/index.tsx
+++ b/src/components/Backup/index.tsx
@@ -4,6 +4,7 @@ import { BackupRestore } from './Restore'
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels'
 import { useStorachaAccount } from '@/hooks/use-plan'
 import { Backup } from '@/app/types'
+import { Suspense } from 'react'
 
 const BackupContainer = styled.div`
   display: flex;
@@ -35,7 +36,9 @@ export const BackupScreen = ({ backup }: { backup?: Backup }) => {
     <BackupContainer>
       <PanelGroup autoSaveId="backup-restore-layout" direction="horizontal">
         <Panel defaultSize={60} minSize={45}>
-          <BackupDetail account={account} backup={backup} />
+          <Suspense>
+            <BackupDetail account={account} backup={backup} />
+          </Suspense>
         </Panel>
         <PanelResizeHandle>
           <ResizeHandleOuter>


### PR DESCRIPTION
we'll probably want to refactor to make this a bit more precise later, but this isn't bad and fixes the build

I considered adding build to the test step so we don't miss this in the future, but it's a little bit of work and I want to unbreak the build