### PR TITLE
fix: add pnpm build to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,4 +10,11 @@ jobs:
       - uses: ./.github/actions/pnpm
       - run: pnpm lint
       - run: pnpm test
+      - name: create .env from .env.tpl
+        run: |
+          cp .env.tpl .env
+          echo "NEXT_PUBLIC_SERVER_DID='did:key:z6Mkk89bC3JrVqKie71YEcc5M1SMVxuCgNx6zLZ8SYJsxALi'" >> .env
+          echo "SERVER_IDENTITY_PRIVATE_KEY=MgCZT5vOnYZoVAeyjnzuJIVY9J4LNtJ+f8Js0cTPuKUpFne0BVEDJjEu6quFIU8yp91/TY/+MYK8GvlKoTDnqOCovCVM=" >> .env
+      - run: pnpm build
+
 


### PR DESCRIPTION
this means we may run the build more than once when deploying in docker, but I think that's actually useful information - the regular build may success and the docker build may fail and that's useful

<img width="1591" alt="Screenshot 2025-04-25 at 3 00 24 PM" src="https://github.com/user-attachments/assets/c54ee52d-3631-47d9-aa37-30562eeb2961" />
