### PR TITLE
fix: Remove "use client" from Dialog component

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import { Dialog as HeadlessDialog, Transition } from '@headlessui/react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import React, { Fragment } from 'react'


### PR DESCRIPTION
As it was, `onClose` was invalid, because it wasn't serializable. `"use client"` marks a client entry module, meaning a point in the tree where a server component renders a client component. A server component can't render this client component, because it can't pass it an `onClose` value. But that's okay, it wouldn't make much sense anyway.




#### PR Dependency Tree


* **PR #67** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)