### PR TITLE
chore: change type of ids from numbers to uuids

### DIFF
--- a/scripts/migrations/00001_initial/index.sql
+++ b/scripts/migrations/00001_initial/index.sql
@@ -1,6 +1,11 @@
+DROP TABLE IF EXISTS snapshots CASCADE;
 DROP TABLE IF EXISTS backups CASCADE;
+DROP TABLE IF EXISTS blobs CASCADE;
+DROP TABLE IF EXISTS auth_sessions;
+DROP TABLE IF EXISTS auth_states;
+
 CREATE TABLE IF NOT EXISTS backups (
-  id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   account_did TEXT NOT NULL,
   name TEXT NOT NULL,
   atproto_account TEXT NOT NULL CHECK (atproto_account LIKE 'did:%'),
@@ -8,14 +13,15 @@ CREATE TABLE IF NOT EXISTS backups (
   include_repository BOOLEAN NOT NULL,
   include_blobs BOOLEAN NOT NULL,
   include_preferences BOOLEAN NOT NULL,
+  delegation_cid TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
-DROP TABLE IF EXISTS snapshots CASCADE;
 CREATE TABLE IF NOT EXISTS snapshots (
-  id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-  backup_id INTEGER NOT NULL,
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  backup_id UUID NOT NULL,
   atproto_account TEXT NOT NULL CHECK (atproto_account LIKE 'did:%'),
+  repo_rev TEXT,
   repository_status TEXT DEFAULT 'not-started' CHECK (
     repository_status IN (
       'not-started',
@@ -46,18 +52,16 @@ CREATE TABLE IF NOT EXISTS snapshots (
   FOREIGN KEY (backup_id) REFERENCES backups(id)
 );
 
-DROP TABLE IF EXISTS blobs CASCADE;
 CREATE TABLE IF NOT EXISTS blobs (
-  cid TEXT,
+  cid TEXT PRIMARY KEY,
   content_type TEXT,
-  backup_id INTEGER,
+  backup_id UUID,
   FOREIGN KEY (backup_id) REFERENCES backups(id),
-  snapshot_id INTEGER NOT NULL,
+  snapshot_id UUID NOT NULL,
   FOREIGN KEY (snapshot_id) REFERENCES snapshots(id),
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
-DROP TABLE IF EXISTS auth_sessions;
 CREATE TABLE IF NOT EXISTS auth_sessions (
   key TEXT PRIMARY KEY,
   value TEXT,
@@ -65,7 +69,6 @@ CREATE TABLE IF NOT EXISTS auth_sessions (
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 
-DROP TABLE IF EXISTS auth_states;
 CREATE TABLE IF NOT EXISTS auth_states (
   key TEXT PRIMARY KEY,
   value TEXT,

--- a/scripts/migrations/00002_add_delegation_to_backup/index.sql
+++ b/scripts/migrations/00002_add_delegation_to_backup/index.sql
@@ -1,3 +1,0 @@
-ALTER TABLE backups ADD delegation_cid TEXT;
-
-ALTER TABLE snapshots ADD repo_rev TEXT;

--- a/src/app/Sidebar.stories.tsx
+++ b/src/app/Sidebar.stories.tsx
@@ -42,7 +42,7 @@ export const WithBackups: Story = {
       ['api', '/api/backups'],
       [
         {
-          id: 1,
+          id: 'abc',
           accountDid: 'did:mailto:gmail.com:timothy-chalamet',
           name: 'Backup #1',
           atprotoAccount: 'did:plc:ro3eio7zgqosf5gnxsq6ik5m',
@@ -54,7 +54,7 @@ export const WithBackups: Story = {
           delegationCid: null,
         },
         {
-          id: 2,
+          id: 'def',
           accountDid: 'did:mailto:gmail.com:timothy-chalamet',
           name: 'Bluesky #452',
           atprotoAccount: 'did:plc:vv44vwwbr3lmbjht3p5fd7wz',
@@ -69,13 +69,13 @@ export const WithBackups: Story = {
     ),
   ],
   args: {
-    selectedBackupId: 1,
+    selectedBackupId: 'abc',
   },
 }
 
 export const WhileBackupsLoading: Story = {
   decorators: [withData(['api', '/api/backups'], new Promise(() => {}))],
   args: {
-    selectedBackupId: 1,
+    selectedBackupId: 'abc',
   },
 }

--- a/src/app/Sidebar.tsx
+++ b/src/app/Sidebar.tsx
@@ -91,7 +91,7 @@ const LogOutButton = styled(BaseLogOutButton)`
 export function Sidebar({
   selectedBackupId,
 }: {
-  selectedBackupId: number | null
+  selectedBackupId: string | null
 }) {
   return (
     <SidebarOutside>
@@ -112,7 +112,7 @@ export function Sidebar({
   )
 }
 
-function Backups({ selectedBackupId }: { selectedBackupId: number | null }) {
+function Backups({ selectedBackupId }: { selectedBackupId: string | null }) {
   const { data } = useSWR(['api', '/api/backups'])
 
   if (!data) return <Loader />

--- a/src/app/api/backups/[id]/blobs/route.ts
+++ b/src/app/api/backups/[id]/blobs/route.ts
@@ -9,7 +9,7 @@ export async function GET(
   const { id } = await params
   const { db } = getStorageContext()
   const { did: account } = await getSession()
-  if (!(await backupOwnedByAccount(db, parseInt(id), account))) {
+  if (!(await backupOwnedByAccount(db, id, account))) {
     return new Response('Not authorized', { status: 401 })
   }
 

--- a/src/app/api/backups/[id]/snapshots/route.ts
+++ b/src/app/api/backups/[id]/snapshots/route.ts
@@ -12,10 +12,10 @@ export async function GET(
   const { id } = await params
   const { db } = getStorageContext()
   const { did: account } = await getSession()
-  if (!(await backupOwnedByAccount(db, parseInt(id), account))) {
+  if (!(await backupOwnedByAccount(db, id, account))) {
     return new Response('Not authorized', { status: 401 })
   }
-  const { results } = await db.findSnapshots(parseInt(id))
+  const { results } = await db.findSnapshots(id)
 
   return Response.json(results)
 }
@@ -28,8 +28,7 @@ export async function POST(
     return new Response('Unauthorized', { status: 401 })
   }
 
-  const { id: idStr } = await params
-  const id = parseInt(idStr)
+  const { id } = await params
   const { db } = getStorageContext()
   const { result: backup } = await db.findBackup(id)
 

--- a/src/app/api/snapshots/[id]/route.ts
+++ b/src/app/api/snapshots/[id]/route.ts
@@ -11,11 +11,11 @@ export async function GET(
   const { id } = await params
   const { db } = getStorageContext()
   const { did: account } = await getSession()
-  if (!(await snapshotOwnedByAccount(db, parseInt(id), account))) {
+  if (!(await snapshotOwnedByAccount(db, id, account))) {
     return new Response('Not authorized', { status: 401 })
   }
 
-  const { result } = await db.findSnapshot(parseInt(id))
+  const { result } = await db.findSnapshot(id)
 
   return Response.json(result)
 }

--- a/src/app/backups/[id]/BackupPage.tsx
+++ b/src/app/backups/[id]/BackupPage.tsx
@@ -4,7 +4,7 @@ import { Sidebar } from '@/app/Sidebar'
 import { useSWR } from '@/app/swr'
 import { BackupScreen } from '@/components/BackupScreen'
 
-export default function BackupPage({ id }: { id: number }) {
+export default function BackupPage({ id }: { id: string }) {
   // TODO: Should we fetch individual backups? We already need the list for the
   // sidebar, and they're not heavy so far, but we should check back on this at
   // the end of the first version.

--- a/src/app/backups/[id]/createSnapshot.ts
+++ b/src/app/backups/[id]/createSnapshot.ts
@@ -9,7 +9,7 @@ export const createSnapshot = async ({
   backupId,
   delegationData,
 }: {
-  backupId: number
+  backupId: string
   delegationData: Uint8Array
 }) => {
   const { db } = getStorageContext()

--- a/src/app/backups/[id]/page.stories.tsx
+++ b/src/app/backups/[id]/page.stories.tsx
@@ -12,7 +12,7 @@ const meta = {
     layout: 'fullscreen',
   },
   args: {
-    id: 1,
+    id: 'abc',
   },
   decorators: [
     withAuthContext({
@@ -33,7 +33,7 @@ const meta = {
       ['api', '/api/backups'],
       [
         {
-          id: 1,
+          id: 'abc',
           accountDid: 'did:mailto:gmail.com:timothy-chalamet',
           name: 'Backup #1',
           atprotoAccount: 'did:plc:ro3eio7zgqosf5gnxsq6ik5m',
@@ -47,11 +47,11 @@ const meta = {
       ]
     ),
     withData(
-      ['api', '/api/backups/1/snapshots'],
+      ['api', '/api/backups/abc/snapshots'],
       [
         {
-          id: 1,
-          backupId: 1,
+          id: 'abc',
+          backupId: 'abc',
           atprotoAccount: 'did:plc:ro3eio7zgqosf5gnxsq6ik5m',
           repositoryStatus: 'success',
           repositoryCid:
@@ -61,8 +61,8 @@ const meta = {
           createdAt: '2025-04-07 19:51:56',
         },
         {
-          id: 2,
-          backupId: 1,
+          id: 'def',
+          backupId: 'abc',
           atprotoAccount: 'did:plc:ro3eio7zgqosf5gnxsq6ik5m',
           repositoryStatus: 'not-started',
           blobsStatus: 'in-progress',

--- a/src/app/backups/[id]/page.tsx
+++ b/src/app/backups/[id]/page.tsx
@@ -10,8 +10,7 @@ export default async function Backup({
 }: {
   params: Promise<{ id: string }>
 }) {
-  const { id: idParam } = await params
-  const id = parseInt(idParam)
+  const { id } = await params
   const { db } = getStorageContext()
   const { did: account } = await getSession()
   if (!(await backupOwnedByAccount(db, id, account))) {

--- a/src/app/backups/new/page.stories.tsx
+++ b/src/app/backups/new/page.stories.tsx
@@ -46,7 +46,7 @@ const meta = {
       ['api', '/api/backups'],
       [
         {
-          id: 1,
+          id: '1234',
           accountDid: 'did:mailto:gmail.com:timothy-chalamet',
           name: 'Backup #1',
           atprotoAccount: 'did:plc:ro3eio7zgqosf5gnxsq6ik5m',
@@ -58,7 +58,7 @@ const meta = {
           includePreferences: false,
         },
         {
-          id: 2,
+          id: '5678',
           accountDid: 'did:mailto:gmail.com:timothy-chalamet',
           name: 'Bluesky #452',
           atprotoAccount: 'did:plc:vv44vwwbr3lmbjht3p5fd7wz',

--- a/src/app/types.tsx
+++ b/src/app/types.tsx
@@ -3,7 +3,7 @@ import { Did } from '@atproto/oauth-client-node'
 export type SpaceDid = Did<'key'>
 
 export type Backup = {
-  id: number
+  id: string
   accountDid: string
   name: string
   atprotoAccount: Did
@@ -26,9 +26,9 @@ export type BackupInput = Input<Backup, 'id'>
 type SnapshotStatus = 'not-started' | 'in-progress' | 'failed' | 'success'
 
 export type Snapshot = {
-  id: number
+  id: string
   atprotoAccount: Did
-  backupId: number
+  backupId: string
   repositoryStatus: SnapshotStatus
   repositoryCid?: string
   blobsStatus: SnapshotStatus
@@ -50,8 +50,8 @@ export type SnapshotInput = Input<
 export interface ATBlob {
   cid: string
   contentType?: string
-  snapshotId: number
-  backupId?: number
+  snapshotId: string
+  backupId?: string
   createdAt: string
 }
 

--- a/src/components/BackupScreen/BackupDetail.tsx
+++ b/src/components/BackupScreen/BackupDetail.tsx
@@ -211,7 +211,7 @@ export const BackupDetail = ({ account, backup }: BackupProps) => {
           )}
           <Stack $gap="2rem">
             {backup ? (
-              <Heading>Backup #{backup.id}</Heading>
+              <Heading>{backup.name}</Heading>
             ) : (
               <Heading>New Backup</Heading>
             )}

--- a/src/components/BackupScreen/Restore.tsx
+++ b/src/components/BackupScreen/Restore.tsx
@@ -81,8 +81,7 @@ export const BackupRestore = ({ backup }: BackupRestoreProps) => {
                   $width="100%"
                 >
                   <Stack $direction="column" $alignItems="flex-start">
-                    <h3>Snapshot {snapshot.id}</h3>
-                    <h3>{formatDate(snapshot.createdAt)}</h3>
+                    <h3>{formatDate(snapshot.createdAt)} Snapshot</h3>
                   </Stack>
                   <Button
                     $background="var(--color-white)"

--- a/src/components/Restore.tsx
+++ b/src/components/Restore.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from 'next/dynamic'
 
-export default function Restore({ snapshotId }: { snapshotId: number }) {
+export default function Restore({ snapshotId }: { snapshotId: string }) {
   const RestoreUI = dynamic(() => import('./RestoreUI'), {
     loading: () => <p>Loading...</p>,
     ssr: false,

--- a/src/components/RestoreUI.tsx
+++ b/src/components/RestoreUI.tsx
@@ -130,7 +130,7 @@ interface RestoreDialogViewProps {
   isPlcRestoreSetup?: boolean
 }
 
-export default function RestoreDialog({ snapshotId }: { snapshotId: number }) {
+export default function RestoreDialog({ snapshotId }: { snapshotId: string }) {
   const { keys } = useKeychainContext()
   const { data: snapshot } = useSWR<Snapshot>([
     'api',

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -114,7 +114,7 @@ export const authorize = async (
 
 export async function backupOwnedByAccount(
   db: BBDatabase,
-  backupId: number,
+  backupId: string,
   account: string
 ) {
   const { result: backup } = await db.findBackup(backupId)
@@ -123,7 +123,7 @@ export async function backupOwnedByAccount(
 
 export async function snapshotOwnedByAccount(
   db: BBDatabase,
-  snapshotId: number,
+  snapshotId: string,
   account: string
 ): Promise<boolean> {
   // TODO: make this one database query

--- a/src/lib/server/backups.ts
+++ b/src/lib/server/backups.ts
@@ -74,11 +74,11 @@ export const createSnapshotForBackup = async (
 }
 
 interface BackupOptions {
-  backupId?: number
+  backupId?: string
 }
 
 const doSnapshot = async (
-  snapshotId: number,
+  snapshotId: string,
   db: BBDatabase,
   atpAgent: AtprotoAgent,
   storachaClient: StorachaClient,

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -138,11 +138,11 @@ function newKvNamespace(table: string): KVNamespace {
 
 export interface BBDatabase {
   addSnapshot: (input: SnapshotInput) => Promise<Snapshot>
-  updateSnapshot: (id: number, input: Partial<Snapshot>) => Promise<Snapshot>
-  findSnapshots: (backupId: number) => Promise<{ results: Snapshot[] }>
-  findSnapshot: (id: number) => Promise<{ result: Snapshot | undefined }>
+  updateSnapshot: (id: string, input: Partial<Snapshot>) => Promise<Snapshot>
+  findSnapshots: (backupId: string) => Promise<{ results: Snapshot[] }>
+  findSnapshot: (id: string) => Promise<{ result: Snapshot | undefined }>
   findBackups: (account: string) => Promise<{ results: Backup[] }>
-  findBackup: (id: number) => Promise<{ result: Backup | undefined }>
+  findBackup: (id: string) => Promise<{ result: Backup | undefined }>
   findScheduledBackups: () => Promise<{ results: Backup[] }>
   addBackup: (input: BackupInput) => Promise<Backup>
   addBlob: (input: ATBlobInput) => Promise<ATBlob>
@@ -202,7 +202,7 @@ export function getStorageContext(): StorageContext {
           results,
         }
       },
-      async findSnapshot(id: number) {
+      async findSnapshot(id: string) {
         const [result] = await sql<Snapshot[]>`
           select *
           from snapshots
@@ -274,7 +274,7 @@ export function getStorageContext(): StorageContext {
           results,
         }
       },
-      async findBackup(id: number) {
+      async findBackup(id: string) {
         const [result] = await sql<Backup[]>`
           select *
           from backups


### PR DESCRIPTION
I floated this in chat and got a good response:

```I'm thinking it would be better to use a UUID. numbers leak information about how many backups we've done in general, and imho kind of look silly because they show up in URLs and won't have any real discernable pattern.
```