### PR TITLE
chore: Stop ignoring `@vercel/ncc`; it's uninstalled now

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -35,9 +35,5 @@
     // Per README, we expect psql to be installed on the system.
     "psql",
   ],
-  "ignoreDependencies": [
-    // Used in Dockerfile, which Knip can't (currently) read.
-    "@vercel/ncc",
-    "chromatic",
-  ],
+  "ignoreDependencies": ["chromatic"],
 }


### PR DESCRIPTION






#### PR Dependency Tree


* **PR #96** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)