### PR TITLE
fix: rework the blobs datamodel

### DIFF
--- a/scripts/migrations/00003_at_blobs/index.sql
+++ b/scripts/migrations/00003_at_blobs/index.sql
@@ -1,0 +1,12 @@
+-- DROP TABLE IF EXISTS at_blobs;
+
+CREATE TABLE IF NOT EXISTS at_blobs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  cid TEXT NOT NULL,
+  content_type TEXT,
+  backup_id UUID,
+  FOREIGN KEY (backup_id) REFERENCES backups(id),
+  snapshot_id UUID NOT NULL,
+  FOREIGN KEY (snapshot_id) REFERENCES snapshots(id),
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);

--- a/src/lib/server/backups.ts
+++ b/src/lib/server/backups.ts
@@ -79,14 +79,10 @@ export const createSnapshotForBackup = async (
 async function isBlobAlreadyBackedUp(
   db: BBDatabase,
   cid: string,
-  backupId?: string
+  backupId: string
 ) {
-  if (backupId) {
-    const { result: existingBlob } = await db.getBlobInBackup(cid, backupId)
-    return Boolean(existingBlob)
-  } else {
-    return false
-  }
+  const { result: existingBlob } = await db.getBlobInBackup(cid, backupId)
+  return Boolean(existingBlob)
 }
 
 interface BackupOptions {
@@ -148,7 +144,10 @@ const doSnapshot = async (
         // TODO handle blobsRes.success == false
         for (const cid of blobsRes.data.cids) {
           // only try to sync this blob if we haven't seen it before
-          if (await isBlobAlreadyBackedUp(db, cid, options.backupId)) {
+          if (
+            options.backupId &&
+            (await isBlobAlreadyBackedUp(db, cid, options.backupId))
+          ) {
             console.log(
               `already backed up blob ${cid} for backup ${options.backupId}, skipping `
             )

--- a/src/lib/server/backups.ts
+++ b/src/lib/server/backups.ts
@@ -144,7 +144,9 @@ const doSnapshot = async (
         // TODO handle blobsRes.success == false
         for (const cid of blobsRes.data.cids) {
           // only try to sync this blob if we've seen it before
-          if (!isBlobAlreadyBackedUp(db, cid, options.backupId)) {
+          if (await isBlobAlreadyBackedUp(db, cid, options.backupId)) {
+            console.log('already backed up blob', cid, 'for backup', options.backupId, ', skipping')
+          } else {
             const blobRes = await atpAgent.com.atproto.sync.getBlob({
               did: atpAgent.did,
               cid,

--- a/src/lib/server/backups.ts
+++ b/src/lib/server/backups.ts
@@ -76,7 +76,11 @@ export const createSnapshotForBackup = async (
   return snapshot
 }
 
-async function isBlobAlreadyBackedUp (db: BBDatabase, cid: string, backupId?: string) {
+async function isBlobAlreadyBackedUp(
+  db: BBDatabase,
+  cid: string,
+  backupId?: string
+) {
   if (backupId) {
     const { result: existingBlob } = await db.getBlobInBackup(cid, backupId)
     return Boolean(existingBlob)
@@ -143,9 +147,15 @@ const doSnapshot = async (
         })
         // TODO handle blobsRes.success == false
         for (const cid of blobsRes.data.cids) {
-          // only try to sync this blob if we've seen it before
+          // only try to sync this blob if we haven't seen it before
           if (await isBlobAlreadyBackedUp(db, cid, options.backupId)) {
-            console.log('already backed up blob', cid, 'for backup', options.backupId, ', skipping')
+            console.log(
+              'already backed up blob',
+              cid,
+              'for backup',
+              options.backupId,
+              ', skipping'
+            )
           } else {
             const blobRes = await atpAgent.com.atproto.sync.getBlob({
               did: atpAgent.did,

--- a/src/lib/server/backups.ts
+++ b/src/lib/server/backups.ts
@@ -150,11 +150,7 @@ const doSnapshot = async (
           // only try to sync this blob if we haven't seen it before
           if (await isBlobAlreadyBackedUp(db, cid, options.backupId)) {
             console.log(
-              'already backed up blob',
-              cid,
-              'for backup',
-              options.backupId,
-              ', skipping'
+              `already backed up blob ${cid} for backup ${options.backupId}, skipping `
             )
           } else {
             const blobRes = await atpAgent.com.atproto.sync.getBlob({

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -192,7 +192,10 @@ export interface BBDatabase {
   findScheduledBackups: () => Promise<{ results: Backup[] }>
   addBackup: (input: BackupInput) => Promise<Backup>
   addBlob: (input: ATBlobInput) => Promise<ATBlob>
-  getBlobInBackup: (cid: string, backupId: string) => Promise<{ result: ATBlob | undefined }>
+  getBlobInBackup: (
+    cid: string,
+    backupId: string
+  ) => Promise<{ result: ATBlob | undefined }>
   findBlobsForBackup: (id: string) => Promise<{ results: ATBlob[] }>
   findBlobsForSnapshot: (id: string) => Promise<{ results: ATBlob[] }>
 }

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -192,7 +192,7 @@ export interface BBDatabase {
   findScheduledBackups: () => Promise<{ results: Backup[] }>
   addBackup: (input: BackupInput) => Promise<Backup>
   addBlob: (input: ATBlobInput) => Promise<ATBlob>
-  getBlob: (cid: string) => Promise<{ result: ATBlob | undefined }>
+  getBlobInBackup: (cid: string, backupId: string) => Promise<{ result: ATBlob | undefined }>
   findBlobsForBackup: (id: string) => Promise<{ results: ATBlob[] }>
   findBlobsForSnapshot: (id: string) => Promise<{ results: ATBlob[] }>
 }
@@ -220,11 +220,12 @@ export function getStorageContext(): StorageContext {
         return results[0]
       },
 
-      async getBlob(cid: string) {
+      async getBlobInBackup(cid: string, backupId: string) {
         const [result] = await sql<ATBlob[]>`
           select *
           from at_blobs
           where cid = ${cid}
+          and backup_id = ${backupId}
         `
         return { result }
       },

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -192,6 +192,7 @@ export interface BBDatabase {
   findScheduledBackups: () => Promise<{ results: Backup[] }>
   addBackup: (input: BackupInput) => Promise<Backup>
   addBlob: (input: ATBlobInput) => Promise<ATBlob>
+  getBlob: (cid: string) => Promise<{ result: ATBlob | undefined }>
   findBlobsForBackup: (id: string) => Promise<{ results: ATBlob[] }>
   findBlobsForSnapshot: (id: string) => Promise<{ results: ATBlob[] }>
 }
@@ -210,7 +211,7 @@ export function getStorageContext(): StorageContext {
       async addBlob(input) {
         console.log('inserting', input)
         const results = await sql<ATBlob[]>`
-        insert into blobs ${sql(input)}
+        insert into at_blobs ${sql(input)}
         returning *
       `
         if (!results[0]) {
@@ -219,16 +220,20 @@ export function getStorageContext(): StorageContext {
         return results[0]
       },
 
+      async getBlob(cid: string) {
+        const [result] = await sql<ATBlob[]>`
+          select *
+          from at_blobs
+          where cid = ${cid}
+        `
+        return { result }
+      },
+
       async findBlobsForBackup(id) {
         if (!validateUUID(id)) return { results: [] }
 
         const results = await sql<ATBlob[]>`
-          select
-            cid,
-            backup_id,
-            snapshot_id,
-            created_at
-          from blobs
+          select * from at_blobs
           where backup_id = ${id}
           `
         return {
@@ -240,12 +245,7 @@ export function getStorageContext(): StorageContext {
         if (!validateUUID(id)) return { results: [] }
 
         const results = await sql<ATBlob[]>`
-          select
-            cid,
-            backup_id,
-            snapshot_id,
-            created_at
-          from blobs
+          select * from at_blobs
           where snapshot_id = ${id}
           `
         return {

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -209,7 +209,6 @@ export function getStorageContext(): StorageContext {
     authStateStore: newKvNamespace('auth_states'),
     db: {
       async addBlob(input) {
-        console.log('inserting', input)
         const results = await sql<ATBlob[]>`
         insert into at_blobs ${sql(input)}
         returning *

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -48,6 +48,7 @@ export type SnapshotInput = Input<
 >
 
 export interface ATBlob {
+  id: string
   cid: string
   contentType?: string
   snapshotId: string
@@ -55,4 +56,4 @@ export interface ATBlob {
   createdAt: string
 }
 
-export type ATBlobInput = Input<ATBlob, 'createdAt'>
+export type ATBlobInput = Input<ATBlob, 'id' | 'createdAt'>


### PR DESCRIPTION
using cid as the database id was a bad idea - I want to be able to track the same cid on different backups and snapshots and this was preventing that, and breaking snapshots

introduce a new table and don't drop the old one - we can do that manually

I merged https://github.com/storacha/bluesky-backup-webapp-server/pull/114 wrong, this fixes that