### PR TITLE
feat: Toast copy is more user-oriented

### DIFF
--- a/src/app/LoggedIn.tsx
+++ b/src/app/LoggedIn.tsx
@@ -105,7 +105,7 @@ function NewBackupForm({
       toast.error(
         error instanceof Error
           ? error.message === 'NEXT_REDIRECT'
-            ? 'Backup created successfully! Redirecting...'
+            ? 'Backup created!'
             : error.message
           : 'Unknown error'
       )


### PR DESCRIPTION
The previous copy was more like a log message. The user doesn't need to be told they were (or are being) redirected, and "successfully" should be assumed.




#### PR Dependency Tree


* **PR #149** 👈
  * **PR #150**

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)