### PR TITLE
fix: render 'back button' on large screens if the path is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ grant all privileges on database bsky_backups_dev to admin;
 
 These names and credentials match the examples in `.env.tpl` and should be customized for your setup.
 
+When you start the dev server for ths first time, be sure to use this command, `pnpm run atproto:generate-jwk` to generate the JWK endpoint key so you don't encounter this:
+
+> missing endpoint error TOKEN_ENDPOINT_PRIVATE_KEY_JWK
+
 ### Set up `ngrok`
 
 1. Run `pnpm dev`.

--- a/src/app/snapshots/[id]/blobs/BlobsPage.tsx
+++ b/src/app/snapshots/[id]/blobs/BlobsPage.tsx
@@ -45,7 +45,7 @@ export default function BlobsPage({ id }: { id: string }) {
           </Center>
         ) : (
           <Stack $gap="1rem">
-            <BackButton />
+            <BackButton path={`/snapshots/${id}`} />
             <Stack
               $direction="row"
               $gap={isMobile ? '1.4rem' : '.8rem'}

--- a/src/app/snapshots/[id]/repo/RepoPage.tsx
+++ b/src/app/snapshots/[id]/repo/RepoPage.tsx
@@ -29,7 +29,7 @@ export default function RepoPage({ id }: { id: string }) {
           <p>Loading repository data...</p>
         ) : (
           <Stack $gap="1rem">
-            <BackButton />
+            <BackButton path={`/snapshots/${id}`} />
             <Stack $gap=".8rem">
               <Heading>
                 Recent Posts

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,23 +1,40 @@
 import { ArrowLeft } from '@phosphor-icons/react'
 import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
 
 import { useMobileScreens } from '@/hooks/use-mobile-screens'
 
 import { Button } from './ui'
 
-export const BackButton = () => {
+export const BackButton = ({ path }: { path?: string }) => {
   const router = useRouter()
   const { isSmallViewPort } = useMobileScreens()
+
+  const goBack = () => {
+    if (path) {
+      router.push(path)
+    } else {
+      router.back()
+    }
+  }
+
+  // we should prefetch the route if the path prop is specified
+  useEffect(() => {
+    if (path) router.prefetch(path)
+    // it is pointless to pass the router as a dependency in this call.
+    // we do not want to call `prefetch` on every render
+    /* eslint-disable react-hooks/exhaustive-deps */
+  }, [path])
   return (
-    isSmallViewPort && (
+    (isSmallViewPort || path) && (
       <Button
         $background="none"
         $color="var(--color-black)"
-        $width="6%"
+        $width="fit-content"
         $alignItems="center"
         $gap="1rem"
-        $padding="0"
-        onClick={() => router.back()}
+        onClick={goBack}
+        noPadding
       >
         <ArrowLeft size={18} />
       </Button>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -17,10 +17,11 @@ const buttonBackgroundColor = (
   }
 }
 
-const ButtonElement = styled.button<Partial<BtnProps>>`
+const ButtonElement = styled.button<Partial<BtnProps & { noPadding: boolean }>>`
   font-family: ${({ $fontFamily = 'var(--font-dm-mono)' }) => $fontFamily};
   font-weight: ${({ $fontWeight = '300' }) => $fontWeight};
-  padding: ${({ $py = '0.75rem', $px = '1rem' }) => `${$py} ${$px}`};
+  padding: ${({ $py, $px, noPadding }) =>
+    `${$py || (noPadding ? '0' : '0.75rem')} ${$px || (noPadding ? '0' : '1rem')}`};
   border-radius: ${({ $borderRadius = '0.75rem' }) => $borderRadius};
   background-color: ${({
     $background = 'var(--color-dark-blue)',
@@ -54,7 +55,8 @@ const ButtonElement = styled.button<Partial<BtnProps>>`
 export const Button = ({
   children,
   ...props
-}: ButtonHTMLAttributes<HTMLButtonElement> & Partial<BtnProps>) => (
+}: ButtonHTMLAttributes<HTMLButtonElement> &
+  Partial<BtnProps & { noPadding: boolean }>) => (
   <ButtonElement {...props}>
     {props.$leftIcon}
     {children}


### PR DESCRIPTION
Initially, `<BackButton />` only renders on mobile and uses router.back(), which pretty much relies on the history API.

Now, it accepts an optional path prop if you want to be explicit about where to 'go back' to.

---
fixes [#434](https://github.com/storacha/project-tracking/issues/434)