### PR TITLE
fix: Tell 1Password to ignore `keyMaterial`

### DIFF
--- a/src/components/ui/KeyImportForm.tsx
+++ b/src/components/ui/KeyImportForm.tsx
@@ -26,6 +26,7 @@ export default function KeyImportForm({
       <Stack $direction="row" $gap="0.5rem">
         <InputField
           type="password"
+          data-1p-ignore
           placeholder="M..."
           label="Private Key"
           {...register('keyMaterial')}


### PR DESCRIPTION
Without this, 1Password will prompt to save the `keyMaterial` field as a password. 1Password is a great place to store the key material, but it doesn't function like a password, so the automatic system doesn't really work for us, and this in particular is not where the value is *created* but where it's *used*.

The `data-1p-ignore` attribute is not documented, but it does appear to work.

#### PR Dependency Tree


* **PR #162** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)