### PR TITLE
feat: Add hover text to `CopyButton`

### DIFF
--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -31,7 +31,8 @@ export default function CopyButton({ text }: CopyButtonProps) {
   }
   return (
     <IconButton
-      aria-label={copied ? 'Copied!' : 'Copy to clipboard'}
+      title={copied ? 'Copied!' : 'Copy to clipboard'}
+      aria-label="Copy to clipboard"
       onClick={copy}
     >
       {copied ? (


### PR DESCRIPTION
Change the hover text (`title`) when clicked. Keep the *label* (`aria-label`), which is still correct once the button is clicked.

#### PR Dependency Tree


* **PR #163** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)