### PR TITLE
refactor: Fix up some CSS

### DIFF
--- a/src/app/atproto/connect/page.tsx
+++ b/src/app/atproto/connect/page.tsx
@@ -37,8 +37,7 @@ const ConnectPage: React.FC = () => {
         <Stack>
           <Heading>Connect your Bluesky Account</Heading>
           <SubHeading>
-            {' '}
-            To get started, please log in to your Bluesky account.{' '}
+            To get started, please log in to your Bluesky account.
           </SubHeading>
         </Stack>
         <form action="/atproto/oauth" method="POST" onSubmit={handleAppend}>

--- a/src/app/identities/[id]/IdentityPage.tsx
+++ b/src/app/identities/[id]/IdentityPage.tsx
@@ -22,9 +22,7 @@ export default function IdentityPage({ atprotoDid }: { atprotoDid: Did }) {
         <Heading>
           Bluesky Account <NoTextTransform>{profile?.handle}</NoTextTransform>
         </Heading>
-        <SubHeading>
-          <NoTextTransform>{atprotoDid}</NoTextTransform>
-        </SubHeading>
+        <SubHeading>{atprotoDid}</SubHeading>
         <Keychain atprotoAccount={atprotoDid} />
       </IdentityStack>
     </>

--- a/src/components/ui/IdentityTransferView.tsx
+++ b/src/components/ui/IdentityTransferView.tsx
@@ -74,7 +74,6 @@ export default function IdentityTransferView({
 }
 
 const Tab = styled.div<{ $active: boolean }>`
-  pointer: cursor;
   padding: 0.1em 1em;
   border-top-right-radius: 0.5rem;
   border-top-left-radius: 0.5rem;

--- a/src/components/ui/KeychainView.tsx
+++ b/src/components/ui/KeychainView.tsx
@@ -480,7 +480,7 @@ type KeychainProps = KeychainContextProps & {
 const KeyItem = styled(Stack)`
   ${roundRectStyle}
   background: var(--color-white);
-  border: 1px solid var(--color-gray-medium)'};
+  border: 1px solid var(--color-gray-medium);
   padding: 1rem;
 `
 

--- a/src/components/ui/KeychainView.tsx
+++ b/src/components/ui/KeychainView.tsx
@@ -91,9 +91,7 @@ function KeyDetails({ dbKey, onDone, importKey }: KeyDetailsProps) {
     <Stack $gap="1rem">
       {did && (
         <Stack>
-          <SubHeading>
-            Key <NoTextTransform>DID</NoTextTransform>
-          </SubHeading>
+          <SubHeading>Key DID</SubHeading>
           <Stack $direction="row" $alignItems="center" $gap="0.5rem">
             <Text>{shortenDID(did)}</Text>
             <CopyButton text={did} />

--- a/src/components/ui/text.tsx
+++ b/src/components/ui/text.tsx
@@ -44,5 +44,4 @@ export const SubHeading = styled.h3`
   font-weight: 600;
   color: var(--color-gray-medium);
   font-size: 0.75rem;
-  text-transform: capitalize;
 `


### PR DESCRIPTION
All functionally refactoring. Not sure why the bad CSS syntax wasn't more of a problem, but it's gone now.

The "big" change is to `SubHeading`, making it not capitalized by default. Turns out it's desired less often than not. Generally, sub-headings probably shouldn't be capitalized anyway. They tend to be sentences, not nouns.

#### PR Dependency Tree


* **PR #165** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)