### PR TITLE
feat: list all snapshots

### DIFF
--- a/src/app/api/backups/[id]/snapshots/route.ts
+++ b/src/app/api/backups/[id]/snapshots/route.ts
@@ -1,6 +1,7 @@
 import { Delegation } from '@ucanto/core'
 import { NextRequest } from 'next/server'
 
+import { PAGINATED_RESULTS_LIMIT } from '@/lib/constants'
 import { backupOwnedByAccount, isCronjobAuthed } from '@/lib/server/auth'
 import { createSnapshotForBackup } from '@/lib/server/backups'
 import { getStorageContext } from '@/lib/server/db'
@@ -16,7 +17,7 @@ export async function GET(
   const { did: account } = await getSession()
 
   const searchParams = request.nextUrl.searchParams
-  const limit = Number(searchParams.get('limit') ?? 10)
+  const limit = Number(searchParams.get('limit') ?? PAGINATED_RESULTS_LIMIT)
   const page = Number(searchParams.get('page') ?? 1)
   if (!(await backupOwnedByAccount(db, id, account))) {
     return new Response('Not authorized', { status: 401 })

--- a/src/app/api/backups/[id]/snapshots/route.ts
+++ b/src/app/api/backups/[id]/snapshots/route.ts
@@ -1,4 +1,5 @@
 import { Delegation } from '@ucanto/core'
+import { NextRequest } from 'next/server'
 
 import { backupOwnedByAccount, isCronjobAuthed } from '@/lib/server/auth'
 import { createSnapshotForBackup } from '@/lib/server/backups'
@@ -7,18 +8,22 @@ import { getSession } from '@/lib/sessions'
 import { cidUrl } from '@/lib/storacha'
 
 export async function GET(
-  request: Request,
+  request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params
   const { db } = getStorageContext()
   const { did: account } = await getSession()
+
+  const searchParams = request.nextUrl.searchParams
+  const limit = Number(searchParams.get('limit') ?? 10)
+  const page = Number(searchParams.get('page') ?? 1)
   if (!(await backupOwnedByAccount(db, id, account))) {
     return new Response('Not authorized', { status: 401 })
   }
-  const { results } = await db.findSnapshots(id)
+  const data = await db.findSnapshots(id, { limit, page })
 
-  return Response.json(results)
+  return Response.json(data)
 }
 
 export async function POST(

--- a/src/app/backups/[id]/BackupPage.tsx
+++ b/src/app/backups/[id]/BackupPage.tsx
@@ -79,9 +79,11 @@ const RightSidebarContent = ({ backup }: { backup: Backup }) => {
       <SnapshotContainer $gap="1rem">
         <Stack $gap="0.5em" $direction="row" $alignItems="center">
           <CreateSnapshotButton backup={backup} />
-          <SnapshotsLink href={`/backups/${backup.id}/snapshots`}>
-            All Snapshots
-          </SnapshotsLink>
+          {snapshots && snapshots?.count > 5 && (
+            <SnapshotsLink href={`/backups/${backup.id}/snapshots`}>
+              All Snapshots
+            </SnapshotsLink>
+          )}
         </Stack>
         <SubHeading>Recent Snapshots</SubHeading>
         <Stack $gap="0.6rem">

--- a/src/app/backups/[id]/BackupPage.tsx
+++ b/src/app/backups/[id]/BackupPage.tsx
@@ -84,14 +84,14 @@ const RightSidebarContent = ({ backup }: { backup: Backup }) => {
           </SnapshotsLink>
         </Stack>
         <SubHeading>Recent Snapshots</SubHeading>
-        <>
+        <Stack $gap="0.6rem">
           {isLoading ? (
             <Center $height="200px">
               <Loader />
             </Center>
           ) : (
             <>
-              {snapshots?.slice(0, 5).map((snapshot) => (
+              {snapshots?.results.slice(0, 5).map((snapshot) => (
                 <SnapshotSummary
                   key={snapshot.id}
                   $background="var(--color-white)"
@@ -112,7 +112,7 @@ const RightSidebarContent = ({ backup }: { backup: Backup }) => {
               ))}
             </>
           )}
-        </>
+        </Stack>
       </SnapshotContainer>
     </>
   )

--- a/src/app/backups/[id]/page.stories.tsx
+++ b/src/app/backups/[id]/page.stories.tsx
@@ -64,30 +64,35 @@ export const WithSnapshots: Story = {
   decorators: [
     withData(
       ['api', '/api/backups/abc/snapshots'],
-      [
-        {
-          id: 'abc',
-          backupId: 'abc',
-          atprotoAccount: 'did:plc:ro3eio7zgqosf5gnxsq6ik5m',
-          repositoryStatus: 'success',
-          repositoryCid:
-            'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy551repo',
-          blobsStatus: 'in-progress',
-          preferencesStatus: 'not-started',
-          createdAt: '2025-04-07 19:51:56',
-        },
-        {
-          id: 'def',
-          backupId: 'abc',
-          atprotoAccount: 'did:plc:ro3eio7zgqosf5gnxsq6ik5m',
-          repositoryStatus: 'not-started',
-          blobsStatus: 'in-progress',
-          preferencesStatus: 'success',
-          preferencesCid:
-            'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy552pref',
-          createdAt: '2025-04-07 20:51:56',
-        },
-      ]
-    ),
-  ],
+      {
+        count: 2,
+        next: null,
+        prev: null,
+        results: [
+          {
+            id: 'abc',
+            backupId: 'abc',
+            atprotoAccount: 'did:plc:ro3eio7zgqosf5gnxsq6ik5m',
+            repositoryStatus: 'success',
+            repositoryCid:
+              'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy551repo',
+            blobsStatus: 'in-progress',
+            preferencesStatus: 'not-started',
+            createdAt: '2025-04-07 19:51:56',
+          },
+          {
+            id: 'def',
+            backupId: 'abc',
+            atprotoAccount: 'did:plc:ro3eio7zgqosf5gnxsq6ik5m',
+            repositoryStatus: 'not-started',
+            blobsStatus: 'in-progress',
+            preferencesStatus: 'success',
+            preferencesCid:
+              'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy552pref',
+            createdAt: '2025-04-07 20:51:56',
+          },
+        ]
+      }
+    )
+  ]
 }

--- a/src/app/backups/[id]/page.stories.tsx
+++ b/src/app/backups/[id]/page.stories.tsx
@@ -62,37 +62,34 @@ export const WithNoSnapshots: Story = {}
 
 export const WithSnapshots: Story = {
   decorators: [
-    withData(
-      ['api', '/api/backups/abc/snapshots'],
-      {
-        count: 2,
-        next: null,
-        prev: null,
-        results: [
-          {
-            id: 'abc',
-            backupId: 'abc',
-            atprotoAccount: 'did:plc:ro3eio7zgqosf5gnxsq6ik5m',
-            repositoryStatus: 'success',
-            repositoryCid:
-              'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy551repo',
-            blobsStatus: 'in-progress',
-            preferencesStatus: 'not-started',
-            createdAt: '2025-04-07 19:51:56',
-          },
-          {
-            id: 'def',
-            backupId: 'abc',
-            atprotoAccount: 'did:plc:ro3eio7zgqosf5gnxsq6ik5m',
-            repositoryStatus: 'not-started',
-            blobsStatus: 'in-progress',
-            preferencesStatus: 'success',
-            preferencesCid:
-              'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy552pref',
-            createdAt: '2025-04-07 20:51:56',
-          },
-        ]
-      }
-    )
-  ]
+    withData(['api', '/api/backups/abc/snapshots'], {
+      count: 2,
+      next: null,
+      prev: null,
+      results: [
+        {
+          id: 'abc',
+          backupId: 'abc',
+          atprotoAccount: 'did:plc:ro3eio7zgqosf5gnxsq6ik5m',
+          repositoryStatus: 'success',
+          repositoryCid:
+            'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy551repo',
+          blobsStatus: 'in-progress',
+          preferencesStatus: 'not-started',
+          createdAt: '2025-04-07 19:51:56',
+        },
+        {
+          id: 'def',
+          backupId: 'abc',
+          atprotoAccount: 'did:plc:ro3eio7zgqosf5gnxsq6ik5m',
+          repositoryStatus: 'not-started',
+          blobsStatus: 'in-progress',
+          preferencesStatus: 'success',
+          preferencesCid:
+            'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy552pref',
+          createdAt: '2025-04-07 20:51:56',
+        },
+      ],
+    }),
+  ],
 }

--- a/src/app/backups/[id]/snapshots/SnapshotPage.tsx
+++ b/src/app/backups/[id]/snapshots/SnapshotPage.tsx
@@ -8,7 +8,7 @@ import { AppLayout } from '@/app/AppLayout'
 import { BackButton } from '@/components/BackButton'
 import { Loader } from '@/components/Loader'
 import { PaginationControls } from '@/components/Pagination'
-import { Box, Center, Heading, Stack, Text } from '@/components/ui'
+import { Box, Center, Heading, Stack } from '@/components/ui'
 import { PAGINATED_RESULTS_LIMIT } from '@/lib/constants'
 import { useSWR } from '@/lib/swr'
 import { formatDate } from '@/lib/ui'
@@ -84,7 +84,7 @@ export default function SnapshotPage({
   const totalPages =
     snapshots && Math.ceil(snapshots?.count / PAGINATED_RESULTS_LIMIT)
 
-  if (!snapshots && !isLoading) return <Text>No Snapshots found</Text>
+  if (!snapshots) return null
 
   return (
     <AppLayout selectedBackupId={backupId}>

--- a/src/app/backups/[id]/snapshots/SnapshotPage.tsx
+++ b/src/app/backups/[id]/snapshots/SnapshotPage.tsx
@@ -31,7 +31,6 @@ const SnapshotLink = styled(Link)`
 
 interface SnapshotPageProps {
   backupId: string
-  pageNumber: number
   snapshots: Snapshot[]
   loading: boolean
 }
@@ -92,7 +91,6 @@ export default function SnapshotPage({
       <Stack $gap="0.8rem">
         <Snapshots
           backupId={backupId}
-          pageNumber={pageNumber}
           loading={isLoading}
           snapshots={snapshots?.results || []}
         />
@@ -101,14 +99,6 @@ export default function SnapshotPage({
           currentPage={pageNumber}
           onChange={(newPage) => setPageNumber(newPage)}
         />
-        <div style={{ display: 'none' }}>
-          <Snapshots
-            backupId={backupId}
-            pageNumber={pageNumber}
-            loading={isLoading}
-            snapshots={snapshots?.results || []}
-          />
-        </div>
       </Stack>
     </AppLayout>
   )

--- a/src/app/backups/[id]/snapshots/SnapshotPage.tsx
+++ b/src/app/backups/[id]/snapshots/SnapshotPage.tsx
@@ -8,7 +8,7 @@ import { AppLayout } from '@/app/AppLayout'
 import { BackButton } from '@/components/BackButton'
 import { Loader } from '@/components/Loader'
 import { PaginationControls } from '@/components/Pagination'
-import { Box, Center, Heading, Stack } from '@/components/ui'
+import { Box, Center, Heading, Stack, Text } from '@/components/ui'
 import { PAGINATED_RESULTS_LIMIT } from '@/lib/constants'
 import { useSWR } from '@/lib/swr'
 import { formatDate } from '@/lib/ui'
@@ -43,35 +43,30 @@ function Snapshots({ snapshots, loading, backupId }: SnapshotPageProps) {
         <BackButton path={`/backups/${backupId}`} />
         <Heading>Snapshots</Heading>
       </Stack>
-      <>
-        {loading ? (
-          <Center $height="200px">
-            <Loader />
-          </Center>
-        ) : (
-          <>
-            {snapshots?.map((snapshot) => (
-              <SnapshotSummary
-                key={snapshot.id}
-                $background="var(--color-white)"
-              >
-                <SnapshotLink href={`/snapshots/${snapshot.id}`}>
-                  <Stack
-                    $direction="row"
-                    $alignItems="center"
-                    $justifyContent="space-between"
-                    $width="100%"
-                  >
-                    <Stack $direction="column" $alignItems="flex-start">
-                      <h3>{formatDate(snapshot.createdAt)} Snapshot</h3>
-                    </Stack>
+      {loading ? (
+        <Center $height="200px">
+          <Loader />
+        </Center>
+      ) : (
+        <>
+          {snapshots?.map((snapshot) => (
+            <SnapshotSummary key={snapshot.id} $background="var(--color-white)">
+              <SnapshotLink href={`/snapshots/${snapshot.id}`}>
+                <Stack
+                  $direction="row"
+                  $alignItems="center"
+                  $justifyContent="space-between"
+                  $width="100%"
+                >
+                  <Stack $direction="column" $alignItems="flex-start">
+                    <h3>{formatDate(snapshot.createdAt)} Snapshot</h3>
                   </Stack>
-                </SnapshotLink>
-              </SnapshotSummary>
-            ))}
-          </>
-        )}
-      </>
+                </Stack>
+              </SnapshotLink>
+            </SnapshotSummary>
+          ))}
+        </>
+      )}
     </SnapshotContainer>
   )
 }
@@ -90,6 +85,8 @@ export default function SnapshotPage({
   const totalPages =
     snapshots && Math.ceil(snapshots?.count / PAGINATED_RESULTS_LIMIT)
 
+  if (!snapshots && !isLoading) return <Text>No Snapshots found</Text>
+
   return (
     <AppLayout selectedBackupId={backupId}>
       <Stack $gap="0.8rem">
@@ -97,7 +94,7 @@ export default function SnapshotPage({
           backupId={backupId}
           pageNumber={pageNumber}
           loading={isLoading}
-          snapshots={snapshots?.results as Snapshot[]}
+          snapshots={snapshots?.results || []}
         />
         <PaginationControls
           totalPages={totalPages ?? 1}
@@ -109,7 +106,7 @@ export default function SnapshotPage({
             backupId={backupId}
             pageNumber={pageNumber}
             loading={isLoading}
-            snapshots={snapshots?.results as Snapshot[]}
+            snapshots={snapshots?.results || []}
           />
         </div>
       </Stack>

--- a/src/app/backups/[id]/snapshots/SnapshotPage.tsx
+++ b/src/app/backups/[id]/snapshots/SnapshotPage.tsx
@@ -1,16 +1,19 @@
 'use client'
 
+import { CaretLeft, CaretRight } from '@phosphor-icons/react'
 import Link from 'next/link'
 import { styled } from 'next-yak'
+import { useState } from 'react'
 
 import { AppLayout } from '@/app/AppLayout'
 import { Loader } from '@/components/Loader'
 import { Box, Center, Heading, Stack } from '@/components/ui'
 import { useSWR } from '@/lib/swr'
 import { formatDate } from '@/lib/ui'
+import { Snapshot } from '@/types'
 
 const SnapshotContainer = styled(Stack)`
-  margin: 4rem;
+  margin: 2rem;
 `
 
 const SnapshotSummary = styled(Box)`
@@ -24,46 +27,117 @@ const SnapshotLink = styled(Link)`
   padding: 1rem;
 `
 
-export default function SnapshotPage({ backupId }: { backupId: string }) {
+interface SnapshotPageProps {
+  backupId: string
+  pageNumber: number
+  snapshots: Snapshot[]
+  loading: boolean
+}
+
+function Snapshots({ snapshots, loading }: SnapshotPageProps) {
+  return (
+    <SnapshotContainer $gap="1rem">
+      <Heading>Snapshots</Heading>
+      <>
+        {loading ? (
+          <Center $height="200px">
+            <Loader />
+          </Center>
+        ) : (
+          <>
+            {snapshots?.map((snapshot) => (
+              <SnapshotSummary
+                key={snapshot.id}
+                $background="var(--color-white)"
+              >
+                <SnapshotLink href={`/snapshots/${snapshot.id}`}>
+                  <Stack
+                    $direction="row"
+                    $alignItems="center"
+                    $justifyContent="space-between"
+                    $width="100%"
+                  >
+                    <Stack $direction="column" $alignItems="flex-start">
+                      <h3>{formatDate(snapshot.createdAt)} Snapshot</h3>
+                    </Stack>
+                  </Stack>
+                </SnapshotLink>
+              </SnapshotSummary>
+            ))}
+          </>
+        )}
+      </>
+    </SnapshotContainer>
+  )
+}
+
+const PaginationControls = styled.div`
+  display: flex;
+  gap: 1.4rem;
+  padding: 0 2rem;
+  align-items: center;
+`
+
+export default function SnapshotPage({
+  backupId,
+}: Pick<SnapshotPageProps, 'backupId'>) {
+  const [pageNumber, setPageNumber] = useState(1)
+
   const { data: snapshots, isLoading } = useSWR([
     'api',
     `/api/backups/${backupId}/snapshots`,
+    { page: pageNumber.toString() },
   ])
+
+  const totalPages = snapshots && Math.ceil(snapshots?.count / 10)
 
   return (
     <AppLayout selectedBackupId={backupId}>
-      <SnapshotContainer $gap="1rem">
-        <Heading>Snapshots</Heading>
-        <>
-          {isLoading ? (
-            <Center $height="200px">
-              <Loader />
-            </Center>
-          ) : (
-            <>
-              {snapshots?.map((snapshot) => (
-                <SnapshotSummary
-                  key={snapshot.id}
-                  $background="var(--color-white)"
+      <Stack $gap="0.8rem">
+        <Snapshots
+          backupId={backupId}
+          pageNumber={pageNumber}
+          loading={isLoading}
+          snapshots={snapshots?.results as Snapshot[]}
+        />
+        <PaginationControls>
+          <button
+            onClick={() => setPageNumber((p) => Math.max(1, p - 1))}
+            disabled={pageNumber === 1}
+          >
+            <CaretLeft size={19} />
+          </button>
+          <div style={{ display: 'flex', gap: '1rem' }}>
+            {Array.from({ length: Number(totalPages) }, (_, index) => {
+              return (
+                <button
+                  key={index}
+                  onClick={() => setPageNumber(index + 1)}
+                  style={{
+                    color: index + 1 === pageNumber ? 'var(--color-dark-blue' : ''
+                  }}
                 >
-                  <SnapshotLink href={`/snapshots/${snapshot.id}`}>
-                    <Stack
-                      $direction="row"
-                      $alignItems="center"
-                      $justifyContent="space-between"
-                      $width="100%"
-                    >
-                      <Stack $direction="column" $alignItems="flex-start">
-                        <h3>{formatDate(snapshot.createdAt)} Snapshot</h3>
-                      </Stack>
-                    </Stack>
-                  </SnapshotLink>
-                </SnapshotSummary>
-              ))}
-            </>
-          )}
-        </>
-      </SnapshotContainer>
+                  {index + 1}
+                </button>
+              )
+            })}
+          </div>
+          <button
+            onClick={() => setPageNumber((p) => p + 1)}
+            disabled={pageNumber >= Number(totalPages)}
+          >
+            <CaretRight size={19} />
+          </button>
+        </PaginationControls>
+        <div style={{ display: 'none' }}>
+          <Snapshots
+            backupId={backupId}
+            pageNumber={pageNumber}
+            loading={isLoading}
+            snapshots={snapshots?.results as Snapshot[]}
+          />
+        </div>
+      </Stack>
     </AppLayout>
   )
 }

--- a/src/app/backups/[id]/snapshots/SnapshotPage.tsx
+++ b/src/app/backups/[id]/snapshots/SnapshotPage.tsx
@@ -1,13 +1,14 @@
 'use client'
 
-import { CaretLeft, CaretRight } from '@phosphor-icons/react'
 import Link from 'next/link'
 import { styled } from 'next-yak'
 import { useState } from 'react'
 
 import { AppLayout } from '@/app/AppLayout'
 import { Loader } from '@/components/Loader'
+import { PaginationControls } from '@/components/Pagination'
 import { Box, Center, Heading, Stack } from '@/components/ui'
+import { PAGINATED_RESULTS_LIMIT } from '@/lib/constants'
 import { useSWR } from '@/lib/swr'
 import { formatDate } from '@/lib/ui'
 import { Snapshot } from '@/types'
@@ -71,13 +72,6 @@ function Snapshots({ snapshots, loading }: SnapshotPageProps) {
   )
 }
 
-const PaginationControls = styled.div`
-  display: flex;
-  gap: 1.4rem;
-  padding: 0 2rem;
-  align-items: center;
-`
-
 export default function SnapshotPage({
   backupId,
 }: Pick<SnapshotPageProps, 'backupId'>) {
@@ -89,7 +83,8 @@ export default function SnapshotPage({
     { page: pageNumber.toString() },
   ])
 
-  const totalPages = snapshots && Math.ceil(snapshots?.count / 10)
+  const totalPages =
+    snapshots && Math.ceil(snapshots?.count / PAGINATED_RESULTS_LIMIT)
 
   return (
     <AppLayout selectedBackupId={backupId}>
@@ -100,35 +95,11 @@ export default function SnapshotPage({
           loading={isLoading}
           snapshots={snapshots?.results as Snapshot[]}
         />
-        <PaginationControls>
-          <button
-            onClick={() => setPageNumber((p) => Math.max(1, p - 1))}
-            disabled={pageNumber === 1}
-          >
-            <CaretLeft size={19} />
-          </button>
-          <div style={{ display: 'flex', gap: '1rem' }}>
-            {Array.from({ length: Number(totalPages) }, (_, index) => {
-              return (
-                <button
-                  key={index}
-                  onClick={() => setPageNumber(index + 1)}
-                  style={{
-                    color: index + 1 === pageNumber ? 'var(--color-dark-blue' : ''
-                  }}
-                >
-                  {index + 1}
-                </button>
-              )
-            })}
-          </div>
-          <button
-            onClick={() => setPageNumber((p) => p + 1)}
-            disabled={pageNumber >= Number(totalPages)}
-          >
-            <CaretRight size={19} />
-          </button>
-        </PaginationControls>
+        <PaginationControls
+          totalPages={totalPages ?? 1}
+          currentPage={pageNumber}
+          onChange={(newPage) => setPageNumber(newPage)}
+        />
         <div style={{ display: 'none' }}>
           <Snapshots
             backupId={backupId}

--- a/src/app/backups/[id]/snapshots/SnapshotPage.tsx
+++ b/src/app/backups/[id]/snapshots/SnapshotPage.tsx
@@ -5,6 +5,7 @@ import { styled } from 'next-yak'
 import { useState } from 'react'
 
 import { AppLayout } from '@/app/AppLayout'
+import { BackButton } from '@/components/BackButton'
 import { Loader } from '@/components/Loader'
 import { PaginationControls } from '@/components/Pagination'
 import { Box, Center, Heading, Stack } from '@/components/ui'
@@ -35,10 +36,13 @@ interface SnapshotPageProps {
   loading: boolean
 }
 
-function Snapshots({ snapshots, loading }: SnapshotPageProps) {
+function Snapshots({ snapshots, loading, backupId }: SnapshotPageProps) {
   return (
     <SnapshotContainer $gap="1rem">
-      <Heading>Snapshots</Heading>
+      <Stack $direction="row" $gap="1rem">
+        <BackButton path={`/backups/${backupId}`} />
+        <Heading>Snapshots</Heading>
+      </Stack>
       <>
         {loading ? (
           <Center $height="200px">

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -34,7 +34,7 @@ export const BackButton = ({ path }: { path?: string }) => {
         $alignItems="center"
         $gap="1rem"
         onClick={goBack}
-        noPadding
+        $noPadding
       >
         <ArrowLeft size={18} />
       </Button>

--- a/src/components/Pagination.stories.tsx
+++ b/src/components/Pagination.stories.tsx
@@ -1,0 +1,53 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+
+import { PaginationControls } from './Pagination'
+
+const meta: Meta<typeof PaginationControls> = {
+  title: 'components/Pagination',
+  component: PaginationControls,
+  args: {
+    totalPages: 20,
+    delta: 3,
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof PaginationControls>
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+function PaginationStoryWrapper(args: any) {
+  const [currentPage, setCurrentPage] = useState(1)
+
+  return (
+    <PaginationControls
+      {...args}
+      currentPage={currentPage}
+      onChange={(page) => setCurrentPage(page)}
+    />
+  )
+}
+
+export const Default: Story = {
+  render: (args) => <PaginationStoryWrapper {...args} />,
+  args: {
+    totalPages: 10,
+    delta: 1,
+  },
+}
+
+export const WithManyPages: Story = {
+  render: (args) => <PaginationStoryWrapper {...args} />,
+  args: {
+    totalPages: 32,
+    delta: 2,
+  },
+}
+
+export const Minimal: Story = {
+  render: (args) => <PaginationStoryWrapper {...args} />,
+  args: {
+    totalPages: 3,
+    delta: 1,
+  },
+}

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,7 +1,7 @@
 import { CaretLeft, CaretRight } from '@phosphor-icons/react'
 import { styled } from 'next-yak'
 
-import { Button, Stack } from './ui'
+import { Box, Button, Stack } from './ui'
 
 const PaginationContainer = styled.div`
   display: flex;
@@ -61,10 +61,10 @@ export const PaginationControls = ({
       >
         <CaretLeft size={20} />
       </Button>
-      <Stack $gap="0.6rem" $direction="row" $height="fit-content">
+      <Stack $gap="0.6rem" $direction="row" $height="fit-content" $alignItems='center'>
         {range.map((value, idx) =>
           value === 'dots' ? (
-            <span key={`dots-${idx}`}>...</span>
+            <Box $height="100%" key={`dots-${idx}`}>...</Box>
           ) : (
             <Button
               key={value}

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -61,10 +61,17 @@ export const PaginationControls = ({
       >
         <CaretLeft size={20} />
       </Button>
-      <Stack $gap="0.6rem" $direction="row" $height="fit-content" $alignItems='center'>
+      <Stack
+        $gap="0.6rem"
+        $direction="row"
+        $height="fit-content"
+        $alignItems="center"
+      >
         {range.map((value, idx) =>
           value === 'dots' ? (
-            <Box $height="100%" key={`dots-${idx}`}>...</Box>
+            <Box $height="100%" key={`dots-${idx}`}>
+              ...
+            </Box>
           ) : (
             <Button
               key={value}

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,0 +1,89 @@
+import { CaretLeft, CaretRight } from '@phosphor-icons/react'
+import { styled } from 'next-yak'
+
+import { Stack } from './ui'
+
+const PaginationContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 2rem;
+`
+
+interface PaginationProps {
+  /** Total number of pages available */
+  totalPages: number
+  /** Current active page number (1-based) */
+  currentPage: number
+  /**
+   * Called when a different page number is selected
+   * @param page - The new page number
+   */
+  onChange: (page: number) => void
+  /**
+   * Number of sibling pages to show on either side of the current page
+   * @default 2
+   */
+  delta?: number
+}
+
+export const PaginationControls = ({
+  totalPages,
+  currentPage,
+  onChange,
+  delta = 2,
+}: PaginationProps) => {
+  if (totalPages <= 1) return null
+
+  const range: (number | 'dots')[] = []
+
+  const left = Math.max(2, currentPage - delta)
+  const right = Math.min(totalPages - 1, currentPage + delta)
+
+  for (let i = 1; i <= totalPages; i++) {
+    if (i === 1 || i === totalPages || (i >= left && i <= right)) {
+      range.push(i)
+    } else if (
+      range[range.length - 1] !== 'dots' &&
+      (i === left - 1 || i === right + 1)
+    ) {
+      range.push('dots')
+    }
+  }
+
+  return (
+    <PaginationContainer>
+      <button
+        onClick={() => onChange(currentPage - 1)}
+        disabled={currentPage === 1}
+      >
+        <CaretLeft size={20} />
+      </button>
+      <Stack $gap="1rem" $direction="row" $height="fit-content">
+        {range.map((value, idx) =>
+          value === 'dots' ? (
+            <span key={`dots-${idx}`}>...</span>
+          ) : (
+            <button
+              key={value}
+              onClick={() => onChange(value)}
+              style={{
+                color: value === currentPage ? 'var(--color-dark-blue)' : '',
+                fontWeight: value === currentPage ? 'bold' : 'normal',
+                textDecoration: value === currentPage ? 'underline' : 'none',
+              }}
+            >
+              {value}
+            </button>
+          )
+        )}
+      </Stack>
+      <button
+        onClick={() => onChange(currentPage + 1)}
+        disabled={currentPage >= totalPages}
+      >
+        <CaretRight size={20} />
+      </button>
+    </PaginationContainer>
+  )
+}

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,13 +1,13 @@
 import { CaretLeft, CaretRight } from '@phosphor-icons/react'
 import { styled } from 'next-yak'
 
-import { Stack } from './ui'
+import { Button, Stack } from './ui'
 
 const PaginationContainer = styled.div`
   display: flex;
   align-items: center;
   gap: 1rem;
-  padding: 1rem 2rem;
+  padding: 0.3rem 2rem;
 `
 
 interface PaginationProps {
@@ -53,37 +53,42 @@ export const PaginationControls = ({
 
   return (
     <PaginationContainer>
-      <button
+      <Button
+        $background="var(--color-white)"
+        $color="var(--color-black)"
         onClick={() => onChange(currentPage - 1)}
         disabled={currentPage === 1}
       >
         <CaretLeft size={20} />
-      </button>
-      <Stack $gap="1rem" $direction="row" $height="fit-content">
+      </Button>
+      <Stack $gap="0.6rem" $direction="row" $height="fit-content">
         {range.map((value, idx) =>
           value === 'dots' ? (
             <span key={`dots-${idx}`}>...</span>
           ) : (
-            <button
+            <Button
               key={value}
               onClick={() => onChange(value)}
+              $background="none"
+              $color={value === currentPage ? 'var(--color-dark-blue)' : ''}
+              $fontWeight={value === currentPage ? '600' : 'normal'}
               style={{
-                color: value === currentPage ? 'var(--color-dark-blue)' : '',
-                fontWeight: value === currentPage ? 'bold' : 'normal',
                 textDecoration: value === currentPage ? 'underline' : 'none',
               }}
             >
               {value}
-            </button>
+            </Button>
           )
         )}
       </Stack>
-      <button
+      <Button
+        $background="var(--color-white)"
+        $color="var(--color-black)"
         onClick={() => onChange(currentPage + 1)}
         disabled={currentPage >= totalPages}
       >
         <CaretRight size={20} />
-      </button>
+      </Button>
     </PaginationContainer>
   )
 }

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -17,11 +17,13 @@ const buttonBackgroundColor = (
   }
 }
 
-const ButtonElement = styled.button<Partial<BtnProps & { noPadding: boolean }>>`
+const ButtonElement = styled.button<
+  Partial<BtnProps & { $noPadding: boolean }>
+>`
   font-family: ${({ $fontFamily = 'var(--font-dm-mono)' }) => $fontFamily};
   font-weight: ${({ $fontWeight = '300' }) => $fontWeight};
-  padding: ${({ $py, $px, noPadding }) =>
-    `${$py || (noPadding ? '0' : '0.75rem')} ${$px || (noPadding ? '0' : '1rem')}`};
+  padding: ${({ $py, $px, $noPadding }) =>
+    `${$py || ($noPadding ? '0' : '0.75rem')} ${$px || ($noPadding ? '0' : '1rem')}`};
   border-radius: ${({ $borderRadius = '0.75rem' }) => $borderRadius};
   background-color: ${({
     $background = 'var(--color-dark-blue)',
@@ -42,6 +44,7 @@ const ButtonElement = styled.button<Partial<BtnProps & { noPadding: boolean }>>`
   transition: background-color 0.2s ease;
   border: none;
   outline: none;
+  align-items: center;
   &:disabled {
     background-color: var(--color-gray-light);
     color: var(--color-gray-medium);
@@ -56,7 +59,7 @@ export const Button = ({
   children,
   ...props
 }: ButtonHTMLAttributes<HTMLButtonElement> &
-  Partial<BtnProps & { noPadding: boolean }>) => (
+  Partial<BtnProps & { $noPadding: boolean }>) => (
   <ButtonElement {...props}>
     {props.$leftIcon}
     {children}

--- a/src/components/ui/Stack.tsx
+++ b/src/components/ui/Stack.tsx
@@ -13,6 +13,7 @@ export const Stack = styled.div<{ $even?: boolean } & Partial<StyleProps>>`
   height: ${({ $height = '' }) => $height};
   border-bottom: ${({ $borderBottom = '' }) => $borderBottom};
   border: ${({ $border = '' }) => $border};
+  align-items: ${({ $alignItems = '' }) => $alignItems};
 
   ${({ $even }) =>
     $even &&

--- a/src/components/ui/style.ts
+++ b/src/components/ui/style.ts
@@ -46,6 +46,7 @@ export type StyleProps = {
   $overflow: Property.Overflow
   $overflowX: Property.OverflowX
   $overflowY: Property.OverflowY
+  $textDecor: Property.TextDecoration
 }
 
 export interface BtnProps extends StyleProps {

--- a/src/components/ui/style.ts
+++ b/src/components/ui/style.ts
@@ -43,6 +43,9 @@ export type StyleProps = {
   $py: `${Property.PaddingTop} ${Property.PaddingBottom}`
   $my: `${Property.MarginTop} ${Property.MarginBottom}`
   $pt: `${Property.PaddingTop}`
+  $overflow: Property.Overflow
+  $overflowX: Property.OverflowX
+  $overflowY: Property.OverflowY
 }
 
 export interface BtnProps extends StyleProps {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -53,3 +53,5 @@ const toWebDID = (input?: string) =>
 export const GATEWAY_ID =
   toWebDID(process.env.NEXT_PUBLIC_STORACHA_GATEWAY_ID) ??
   toWebDID('did:web:w3s.link')
+
+export const PAGINATED_RESULTS_LIMIT = 10

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -302,7 +302,7 @@ export function getStorageContext(): StorageContext {
         }
         return results[0]
       },
-      async findSnapshots(backupId, options?: Partial<PaginatedResultParams>) {
+      async findSnapshots(backupId, options?: PaginatedResultParams) {
         const { limit = PAGINATED_RESULTS_LIMIT, page = 1 } = options ?? {}
         const offset = (page - 1) * limit
 
@@ -330,14 +330,10 @@ export function getStorageContext(): StorageContext {
         `
 
         const count = Number(total[0]?.count) ?? 0
-        const totalPages = Math.ceil(count / limit)
-        const getPageUrl = (pageNumber: number) =>
-          `${process.env.NEXT_PUBLIC_APP_URI!}/api/backups/${backupId}/snapshots?page=${pageNumber}&limit=${limit}`
+
         return {
           count: count,
-          next: page < totalPages ? getPageUrl(page + 1) : null,
-          prev: page > 1 ? getPageUrl(page - 1) : null,
-          results,
+          results: results || [],
         }
       },
       async addBackup(input) {

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -333,7 +333,7 @@ export function getStorageContext(): StorageContext {
 
         return {
           count: count,
-          results: results || [],
+          results: results,
         }
       },
       async addBackup(input) {

--- a/src/lib/server/db.ts
+++ b/src/lib/server/db.ts
@@ -19,6 +19,8 @@ import {
   SnapshotInput,
 } from '@/types'
 
+import { PAGINATED_RESULTS_LIMIT } from '../constants'
+
 // will use psql environment variables
 // https://github.com/porsager/postgres?tab=readme-ov-file#environmental-variables
 
@@ -301,7 +303,7 @@ export function getStorageContext(): StorageContext {
         return results[0]
       },
       async findSnapshots(backupId, options?: Partial<PaginatedResultParams>) {
-        const { limit = 10, page = 1 } = options ?? {}
+        const { limit = PAGINATED_RESULTS_LIMIT, page = 1 } = options ?? {}
         const offset = (page - 1) * limit
 
         if (!validateUUID(backupId))

--- a/src/lib/swr.tsx
+++ b/src/lib/swr.tsx
@@ -6,7 +6,14 @@ import React from 'react'
 import useSWRBase, { SWRConfig, SWRConfiguration, SWRResponse } from 'swr'
 import useSWRMutationBase, { MutationFetcher } from 'swr/mutation'
 
-import { ATBlob, Backup, ProfileData, RotationKey, Snapshot } from '@/types'
+import {
+  ATBlob,
+  Backup,
+  PaginatedResult,
+  ProfileData,
+  RotationKey,
+  Snapshot,
+} from '@/types'
 
 // This type defines what's fetchable with `useSWR`. It is a union of key/data
 // pairs. The key can match a pattern by being as wide as it needs to be.
@@ -14,8 +21,13 @@ type Fetchable =
   | [['api', '/session/did', Record<never, string>?], string]
   | [['api', '/api/backups', Record<string, string>?], Backup[]]
   | [
-      ['api', `/api/backups/${string}/snapshots`, Record<string, string>?],
-      Snapshot[],
+      [
+        'api',
+        `/api/backups/${string}/snapshots`,
+        { page?: string; limit?: string }?,
+        Record<string, string>?,
+      ],
+      PaginatedResult<Snapshot>,
     ]
   | [['api', `/api/backups/${string}/blobs`, Record<string, string>?], ATBlob[]]
   | [['api', `/api/snapshots/${string}`, Record<string, string>?], Snapshot]

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -180,11 +180,11 @@ export type RotationKeyClientInput = Input<RotationKeyInput, 'storachaAccount'>
 export type PaginatedResult<T> = {
   count: number
   results: T[]
-  next: string | null
-  prev: string | null
+  next?: string | null
+  prev?: string | null
 }
 
 export type PaginatedResultParams = {
-  limit: number
-  page: number
+  limit?: number
+  page?: number
 }

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -176,3 +176,15 @@ export interface RotationKey {
 export type RotationKeyInput = Input<RotationKey, 'createdAt' | 'keypair'>
 
 export type RotationKeyClientInput = Input<RotationKeyInput, 'storachaAccount'>
+
+export type PaginatedResult<T> = {
+  count: number
+  results: T[]
+  next: string | null
+  prev: string | null
+}
+
+export type PaginatedResultParams = {
+  limit: number
+  page: number
+}


### PR DESCRIPTION
I've updated the `findSnaphots` method in the storage context to return paged results and updated the API routes to access this data with query parameters

In the snapshot component, there's a tiny UX hack where I'm rendering the Snapshots in a div that is hidden. This ensures that the SWR cache is always updated with fresh data for the next page, allowing navigation to be instant.

addresses [#448](https://github.com/storacha/project-tracking/issues/448)
