### PR TITLE
fix: polish up the bluesky account connection flow

### DIFF
--- a/src/app/atproto/connect/connectHandle.ts
+++ b/src/app/atproto/connect/connectHandle.ts
@@ -1,22 +1,25 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+
 import { createClient } from '@/lib/atproto'
 
-export async function POST(request: Request) {
-  const formData = await request.formData()
+export default async function connectHandle(formData: FormData) {
   let handle = formData.get('handle')
   const account = formData.get('account')
 
   if (!handle || !(typeof handle === 'string')) {
-    return new Response('Missing handle', { status: 400 })
+    throw new Error('Missing handle')
   }
   if (!handle.includes('.')) {
     handle = `${handle}.bsky.social`
   }
 
   if (!account || !(typeof account === 'string')) {
-    return new Response('Missing account', { status: 400 })
+    throw new Error('Missing account')
   }
 
   const client = await createClient({ account: account })
   const url = await client.authorize(handle)
-  return Response.redirect(url)
+  redirect(url.toString())
 }

--- a/src/app/atproto/connect/error.tsx
+++ b/src/app/atproto/connect/error.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useEffect } from 'react'
+
+import { Box, Button, Center, Heading, Stack, Text } from '@/components/ui'
+import { logAndCaptureError } from '@/lib/sentry'
+
+import { ConnectStack } from './page'
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  useEffect(() => {
+    logAndCaptureError(error)
+  }, [error])
+
+  return (
+    <Center $height="100vh">
+      <ConnectStack $gap="1.2rem" $width="100%">
+        <Stack>
+          <Heading>Connect your Bluesky Account</Heading>
+        </Stack>
+        <Text $fontSize="1em">Oh no - something went wrong:</Text>
+        <Box $borderStyle="solid">
+          <Text $fontSize="0.75em">{error.message}</Text>
+        </Box>
+        <Button onClick={() => reset()}>Try Again</Button>
+      </ConnectStack>
+    </Center>
+  )
+}

--- a/src/app/atproto/connect/error.tsx
+++ b/src/app/atproto/connect/error.tsx
@@ -5,7 +5,7 @@ import { useEffect } from 'react'
 import { Box, Button, Center, Heading, Stack, Text } from '@/components/ui'
 import { logAndCaptureError } from '@/lib/sentry'
 
-import { ConnectStack } from './page'
+import { ConnectStack } from './ui'
 
 export default function Error({
   error,

--- a/src/app/atproto/connect/page.tsx
+++ b/src/app/atproto/connect/page.tsx
@@ -1,35 +1,45 @@
 'use client'
+import Form from 'next/form'
 import { styled } from 'next-yak'
 import React from 'react'
+import { useFormStatus } from 'react-dom'
 
 import {
-  Button,
   Center,
   Heading,
   InputField,
   Stack,
+  StatefulButton,
   SubHeading,
 } from '@/components/ui'
 import { useStorachaAccount } from '@/hooks/use-plan'
 
-const ConnectStack = styled(Stack)`
+import connectHandle from './connectHandle'
+
+export const ConnectStack = styled(Stack)`
   padding: 0 2rem;
 `
+
+const ConnectButton = () => {
+  const { pending } = useFormStatus()
+  console.log('CONPEND', pending)
+  return (
+    <StatefulButton
+      isLoading={pending}
+      disabled={pending}
+      $background="var(--color-dark-blue)"
+      $height="fit-content"
+      $fontSize="0.75rem"
+      type="submit"
+    >
+      Connect
+    </StatefulButton>
+  )
+}
 
 const ConnectPage: React.FC = () => {
   const account = useStorachaAccount()
   if (!account) return null
-
-  const handleAppend = (e: React.FormEvent<HTMLFormElement>) => {
-    const handleInput = e.currentTarget.elements.namedItem(
-      'handle'
-    ) as HTMLInputElement
-    const handle = handleInput.value.trim()
-
-    if (!handle.includes('.')) {
-      handleInput.value = `${handle}.bsky.social`
-    }
-  }
 
   return (
     <Center $height="100vh">
@@ -40,7 +50,7 @@ const ConnectPage: React.FC = () => {
             To get started, please log in to your Bluesky account.
           </SubHeading>
         </Stack>
-        <form action="/atproto/oauth" method="POST" onSubmit={handleAppend}>
+        <Form action={connectHandle}>
           <input type="hidden" name="account" value={account.did()} />
           <Stack $gap="1rem">
             <InputField
@@ -49,16 +59,9 @@ const ConnectPage: React.FC = () => {
               label="Bluesky Handle"
               placeholder="Enter your handle"
             />
-            <Button
-              $background="var(--color-dark-blue)"
-              $height="fit-content"
-              $fontSize="0.75rem"
-              type="submit"
-            >
-              Connect
-            </Button>
+            <ConnectButton />
           </Stack>
-        </form>
+        </Form>
       </ConnectStack>
     </Center>
   )

--- a/src/app/atproto/connect/page.tsx
+++ b/src/app/atproto/connect/page.tsx
@@ -1,6 +1,5 @@
 'use client'
 import Form from 'next/form'
-import { styled } from 'next-yak'
 import React from 'react'
 import { useFormStatus } from 'react-dom'
 
@@ -15,10 +14,7 @@ import {
 import { useStorachaAccount } from '@/hooks/use-plan'
 
 import connectHandle from './connectHandle'
-
-export const ConnectStack = styled(Stack)`
-  padding: 0 2rem;
-`
+import { ConnectStack } from './ui'
 
 const ConnectButton = () => {
   const { pending } = useFormStatus()

--- a/src/app/atproto/connect/page.tsx
+++ b/src/app/atproto/connect/page.tsx
@@ -22,7 +22,6 @@ export const ConnectStack = styled(Stack)`
 
 const ConnectButton = () => {
   const { pending } = useFormStatus()
-  console.log('CONPEND', pending)
   return (
     <StatefulButton
       isLoading={pending}

--- a/src/app/atproto/connect/ui.tsx
+++ b/src/app/atproto/connect/ui.tsx
@@ -1,0 +1,7 @@
+import { styled } from 'next-yak'
+
+import { Stack } from '@/components/ui'
+
+export const ConnectStack = styled(Stack)`
+  padding: 0 2rem;
+`


### PR DESCRIPTION
1) use a server action to enable us to show progress (I tried a few other ways to no avail) 
2) move handle inference to the server action - the quick little handle update didn't look great and the user sees the full handle on the next screen
3) add error handling - we were just throwing an error if a user, for instance, entered a nonexistent handle. now we show the error and let them reset the form, per the [next.js docs](https://nextjs.org/docs/app/api-reference/file-conventions/error)