### PR TITLE
feat: disable identity transfer for now

### DIFF
--- a/src/components/ui/IdentityTransfer.tsx
+++ b/src/components/ui/IdentityTransfer.tsx
@@ -4,6 +4,7 @@ import { Agent, CredentialSession } from '@atproto/api'
 import { useState } from 'react'
 
 import { ATPROTO_DEFAULT_SINK } from '@/lib/constants'
+import * as plc from '@/lib/crypto/plc'
 import { createServiceJwt } from '@/lib/jwt'
 import { createPlcUpdateOp } from '@/lib/plc'
 import {
@@ -37,6 +38,19 @@ export function IdentityTransfer({
   const [isIdentityTransferred, setIsIdentityTransferred] =
     useState<boolean>(false)
 
+  async function takeControl() {
+    if (!profile) throw new Error('profile not defined, cannot take control')
+
+    const op = await createPlcUpdateOp(profile, rotationKey, {
+      verificationMethods: {
+        ...profile.verificationMethods,
+        atproto: rotationKey.id,
+      },
+    })
+    const client = new plc.Client('https://plc.directory')
+    await client.sendOperation(profile.did, op)
+  }
+
   const loginToSink: LoginFn = async (
     identifier,
     password,
@@ -57,22 +71,19 @@ export function IdentityTransfer({
       server: ATPROTO_DEFAULT_SINK,
     }
   ) => {
-    if (!rotationKey.keypair)
+    if (!rotationKey.keypair) {
       throw new Error(
         'cannot create account - rotation key private key is not loaded'
       )
+    }
+
+    await takeControl()
 
     const session = new CredentialSession(new URL(httpsify(server)))
     const agent = new Agent(session)
 
     const describeRes = await agent.com.atproto.server.describeServer()
     const newServerDid = describeRes.data.did
-    console.log('creating service JWT for ', {
-      iss: profile.did,
-      aud: newServerDid,
-      lxm: 'com.atproto.server.createAccount',
-      keypair: rotationKey.keypair.did(),
-    })
     const serviceJwt = await createServiceJwt({
       iss: profile.did,
       aud: newServerDid,
@@ -123,8 +134,6 @@ export function IdentityTransfer({
       operation: plcOp,
     })
     await sinkAgent.com.atproto.server.activateAccount()
-    // TODO: I think we need to do this to be complete, but it currently throws an error
-    //await sourceAgent.com.atproto.server.deactivateAccount()
     setIsTransferringIdentity(false)
     setIsIdentityTransferred(true)
   }

--- a/src/components/ui/IdentityTransferView.tsx
+++ b/src/components/ui/IdentityTransferView.tsx
@@ -61,7 +61,7 @@ export default function IdentityTransferView({
       ) : (
         <Stack $gap="1rem">
           <Stack $gap="0.25rem">
-            <Heading>Data Restore</Heading>
+            <Heading>Transfer Identity</Heading>
             <SubHeading>
               Please login to your new account or create a new ATProto account.
             </SubHeading>

--- a/src/components/ui/KeychainView.tsx
+++ b/src/components/ui/KeychainView.tsx
@@ -8,11 +8,11 @@ import {
   EyeSlashIcon,
   GearIcon,
   IdentificationBadgeIcon,
-  KeyIcon,
   TrashIcon,
   //  Trash,
 } from '@phosphor-icons/react'
 import { base64pad } from 'multiformats/bases/base64'
+import { useSearchParams } from 'next/navigation'
 import { styled } from 'next-yak'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -21,8 +21,6 @@ import { mutate } from 'swr'
 import { KeychainContextProps } from '@/contexts/keychain'
 import { useProfile } from '@/hooks/use-profile'
 import { ATPROTO_DEFAULT_SOURCE } from '@/lib/constants'
-import * as plc from '@/lib/crypto/plc'
-import { createPlcUpdateOp } from '@/lib/plc'
 import { shortenDID } from '@/lib/ui'
 import { ProfileData, RotationKey } from '@/types'
 
@@ -171,13 +169,6 @@ function isCurrentRotationKey(
   profile: ProfileData
 ): boolean {
   return profile.rotationKeys.includes(rotationKey.id)
-}
-
-function isCurrentVerificationKey(
-  rotationKey: RotationKey,
-  profile: ProfileData
-): boolean {
-  return profile.verificationMethods.atproto === rotationKey.id
 }
 
 interface AtprotoLoginFormProps {
@@ -389,27 +380,13 @@ function RotationKeyStatus({
   hydrateKey: KeyHydrateFn
   onDone: () => void
 }) {
-  const { data: profile, mutate } = useProfile(did)
+  const { data: profile } = useProfile(did)
   const { handle } = profile || {}
-
+  const params = useSearchParams()
   const isRotationKey = profile && isCurrentRotationKey(rotationKey, profile)
   const isSignable = Boolean(rotationKey.keypair)
-  const isSigningKey = profile?.verificationMethods?.atproto === rotationKey.id
   const [isAddingKey, setIsAddingKey] = useState(false)
   const [isTransferringIdentity, setIsTransferringIdentity] = useState(false)
-  async function takeControl() {
-    if (!profile) throw new Error('profile not defined, cannot take control')
-
-    const op = await createPlcUpdateOp(profile, rotationKey, {
-      verificationMethods: {
-        ...profile.verificationMethods,
-        atproto: rotationKey.id,
-      },
-    })
-    const client = new plc.Client('https://plc.directory')
-    await client.sendOperation(profile.did, op)
-    await mutate()
-  }
   if (!profile) return null
   return isAddingKey ? (
     <AddRotationKey did={did} rotationKey={rotationKey} onDone={onDone} />
@@ -443,29 +420,16 @@ function RotationKeyStatus({
             </Button>
           )}
         </Stack>
-        <Stack $gap="1rem">
-          <Text $fontSize="1rem" $color="var(--color-black)">
-            {isSigningKey ? <>Is</> : <>Is not</>} controlling {profile.handle}.
-          </Text>
-          {isRotationKey && isSignable && !isSigningKey && (
-            <Button
-              onClick={() => {
-                takeControl()
-              }}
-            >
-              Take Control
-            </Button>
-          )}
-        </Stack>
       </Stack>
       <Stack $direction="row" $gap="1rem">
-        {isSigningKey && isSignable && (
+        {isRotationKey && isSignable && (
           <Button
+            disabled={!params.get('identity-transfer')}
             onClick={() => {
               setIsTransferringIdentity(true)
             }}
           >
-            Transfer Identity
+            Transfer Identity (coming soon!)
           </Button>
         )}
 
@@ -563,24 +527,6 @@ export default function KeychainView({
                     <CopyButton text={key.id} />
                   </Stack>
                   <Stack $direction="row" $gap="0.5rem">
-                    <Button
-                      $variant="outline"
-                      className="p-1"
-                      onClick={() => openRotationKeyStatus(key)}
-                      aria-label="Rotation key status"
-                    >
-                      <KeyIcon
-                        size="16"
-                        color={
-                          rotationKeys
-                            ? isCurrentVerificationKey(key, profile)
-                              ? 'var(--color-green)'
-                              : 'var(--color-dark-red)'
-                            : 'var(--color-gray-medium)'
-                        }
-                      />
-                    </Button>
-
                     <Button
                       $variant="outline"
                       className="p-1"


### PR DESCRIPTION
Remove the whole "take control" concept entirely - it actually isn't necessary for anything other than creating a user account.

We do still need to take control of a DID in order to create a new account with the same `did:plc` - move `takeControl` there and use it when necessary, but also introduce a feature flag so we can ship before identity transfer is fully ready for the masses.

Users can now add `?identity-transfer=true` to the end of their URL to enable the identity transfer flow.

<img width="840" alt="Screenshot 2025-06-04 at 10 33 41 AM" src="https://github.com/user-attachments/assets/c91361d3-7320-47ce-a319-e29199495d2d" />
