### PR TITLE
feat: explainers and mobile improvements

### DIFF
--- a/src/app/LoggedIn.tsx
+++ b/src/app/LoggedIn.tsx
@@ -9,7 +9,7 @@ import { toast } from 'sonner'
 import { BackupDetail } from '@/components/BackupScreen/BackupDetail'
 import { FullscreenLoader } from '@/components/Loader'
 import StripePricingTable from '@/components/StripePricingTable'
-import { Box, Center, Heading, Stack, Text } from '@/components/ui'
+import { Box, Explainer, ExText, Heading, Stack, Text } from '@/components/ui'
 import { CreateButton } from '@/components/ui/CreateButton'
 import { useMobileScreens } from '@/hooks/use-mobile-screens'
 import { usePlan, useStorachaAccount } from '@/hooks/use-plan'
@@ -132,8 +132,38 @@ const PricingTableContainer = styled(Stack)`
   padding-top: 2rem;
 `
 
+const BackupExplainer = () => (
+  <Explainer>
+    <ExText>
+      Connect and select a Bluesky account you&apos;d like to start backing up,
+      and then create a Storacha space you&apos;d like to start saving data to.
+    </ExText>
+    <ExText $fontSize="0.875em" $fontWeight="600">
+      Once you create a backup, we&apos;ll make a snapshot of your publicly
+      available Bluesky data - posts, images, videos, follows and followers,
+      blocks, and more - every hour. Thanks to Storacha&apos;s content-addressed
+      storage, we we&apos;ll only ever store new data - look ma, no dupes!
+    </ExText>
+  </Explainer>
+)
+
+const SmallExplainerContainer = styled.div`
+  margin-top: 3em;
+  margin-bottom: 1em;
+  padding-bottom: 1.5em;
+  border-bottom: 1px solid var(--color-gray-medium);
+`
+
+const BigExplainerContainer = styled.div`
+  margin-top: 1em;
+`
+
+const CreateBackupText = styled(Text)`
+  margin-top: 1em;
+`
+
 export function LoggedIn() {
-  const { isMobile } = useMobileScreens()
+  const { isSmallViewPort } = useMobileScreens()
   const [{ client }] = useAuthenticator()
   const account = useStorachaAccount()
   const { error: sessionDIDError, mutate } = useSWR(['api', '/session/did'])
@@ -165,17 +195,26 @@ export function LoggedIn() {
           <BackupScreen
             selectedBackupId={null}
             rightPanelContent={
-              <Center $height={isMobile ? '45vh' : '90vh'}>
-                <Text $fontWeight="600">
-                  Press &quot;Create Backup&quot; to get started!
-                </Text>
-              </Center>
+              isSmallViewPort ? (
+                <CreateBackupText>Create a backup above.</CreateBackupText>
+              ) : (
+                <BigExplainerContainer>
+                  <BackupExplainer />
+                </BigExplainerContainer>
+              )
             }
           >
-            <NewBackupForm account={account}>
-              <BackupDetail />
-              <CreateBackupButton />
-            </NewBackupForm>
+            <Stack>
+              {isSmallViewPort && (
+                <SmallExplainerContainer>
+                  <BackupExplainer />
+                </SmallExplainerContainer>
+              )}
+              <NewBackupForm account={account}>
+                <BackupDetail />
+                <CreateBackupButton />
+              </NewBackupForm>
+            </Stack>
           </BackupScreen>
         ) : (
           <PricingTableContainer $alignItems="center" $gap="1rem">

--- a/src/app/backups/[id]/RightSidebarContent.tsx
+++ b/src/app/backups/[id]/RightSidebarContent.tsx
@@ -12,6 +12,8 @@ import {
   Box,
   Button,
   Center,
+  Explainer,
+  ExText,
   Spinner,
   Stack,
   SubHeading,
@@ -25,7 +27,7 @@ import { Backup, PaginatedResult, Snapshot } from '@/types'
 import { CreateSnapshotButton } from './CreateSnapshotButton'
 
 const SnapshotContainer = styled(Stack)`
-  margin-top: 4rem;
+  margin-top: 3rem;
 `
 
 const Details = styled(Stack)`
@@ -96,8 +98,8 @@ export const RightSidebarContent = ({ backup }: { backup: Backup }) => {
           <DetailValue>{backup.archived ? 'yes' : 'no'}</DetailValue>
         </Stack>
       </Details>
-      <SnapshotContainer $gap="1rem">
-        <Stack $gap="0.5em" $direction="row" $alignItems="center">
+      <SnapshotContainer $gap="2rem">
+        <Stack $gap="0.5em" $direction="row" $alignItems="center" $my="1rem">
           <CreateSnapshotButton backup={backup} />
           {snapshots && snapshots?.count > 5 && (
             <SnapshotsLink href={`/backups/${backup.id}/snapshots`}>
@@ -105,14 +107,24 @@ export const RightSidebarContent = ({ backup }: { backup: Backup }) => {
             </SnapshotsLink>
           )}
         </Stack>
-        <SubHeading>Recent Snapshots</SubHeading>
         <Stack $gap="0.6rem">
           {isLoading ? (
             <Center $height="200px">
               <Loader />
             </Center>
+          ) : snapshots?.results.length === 0 ? (
+            <Explainer>
+              <ExText>
+                We&apos;ll take a snapshot of your Bluesky account every hour.
+              </ExText>
+              <ExText>
+                If you would like to create a snapshot now, click &ldquo;Create
+                Snapshot&rdquo; above.
+              </ExText>
+            </Explainer>
           ) : (
             <>
+              <SubHeading>Recent Snapshots</SubHeading>
               {snapshots?.results.slice(0, 5).map((snapshot) => (
                 <SnapshotSummary
                   key={snapshot.id}

--- a/src/components/BackupScreen/BackupDetail.tsx
+++ b/src/components/BackupScreen/BackupDetail.tsx
@@ -48,7 +48,7 @@ const BackupNameInput = styled.input`
   width: 100%;
   font-weight: 700;
   font-size: 1.125rem;
-  padding: 0.5rem;
+  padding: 0.5rem 0;
   transition: border-color 0.2s ease;
 
   &::placeholder {

--- a/src/components/BackupScreen/BackupScreen.tsx
+++ b/src/components/BackupScreen/BackupScreen.tsx
@@ -37,7 +37,7 @@ export const BackupScreen = ({
       rightPanelContent={
         <Suspense>
           <RightPanel>
-            <Heading>Backup & Restore</Heading>
+            <Heading>Details</Heading>
             {rightSidebarContent}
           </RightPanel>
         </Suspense>

--- a/src/components/SharedScreen.tsx
+++ b/src/components/SharedScreen.tsx
@@ -48,8 +48,6 @@ const MobileLayout = styled.div`
 `
 
 const MobileTopSection = styled.div`
-  height: 40vh;
-  min-height: 40vh;
   position: relative;
 `
 

--- a/src/components/ui/text.tsx
+++ b/src/components/ui/text.tsx
@@ -1,5 +1,6 @@
 import { styled } from 'next-yak'
 
+import { Stack } from './Stack'
 import { StyleProps } from './style'
 
 export type TextProps = Partial<
@@ -44,4 +45,13 @@ export const SubHeading = styled.h3`
   font-weight: 600;
   color: var(--color-gray-medium);
   font-size: 0.75rem;
+`
+
+export const Explainer = styled(Stack)`
+  gap: 1em;
+`
+
+export const ExText = styled(Text)`
+  font-size: 0.875em;
+  font-weight: 600;
 `

--- a/src/hooks/use-mobile-screens.ts
+++ b/src/hooks/use-mobile-screens.ts
@@ -2,7 +2,7 @@ import { useMediaQuery } from 'react-responsive'
 
 export const useMobileScreens = () => {
   const isMobile = useMediaQuery({ query: '(max-width: 576px)' })
-  const isTablet = useMediaQuery({ minWidth: 768, maxWidth: 992 })
+  const isTablet = useMediaQuery({ minWidth: 576, maxWidth: 992 })
   // laptop breakpoint/screens that do not cross the 1024px threshold
   const isBaseLaptop = useMediaQuery({ minWidth: 993, maxWidth: 1024 })
 


### PR DESCRIPTION
1) add explanatory text in the first-run flow to help users understand what they're doing 
2) make "tablet" responsive breakpoint go down to the mobile one - there was a weird intermediary state with no responsive flags