### PR TITLE
fix: assorted changes from feedback from @alanshaw

### DIFF
--- a/src/app/BackupExplainer.tsx
+++ b/src/app/BackupExplainer.tsx
@@ -1,0 +1,17 @@
+'use client'
+import { Explainer, ExText } from '@/components/ui'
+
+export const BackupExplainer = () => (
+  <Explainer>
+    <ExText>
+      Connect and select a Bluesky account you&apos;d like to start backing up,
+      and then create a Storacha space you&apos;d like to start saving data to.
+    </ExText>
+    <ExText $fontSize="0.875em" $fontWeight="600">
+      Once you create a backup, we&apos;ll make a snapshot of your publicly
+      available Bluesky data - posts, images, videos, follows and followers,
+      blocks, and more - every hour. Thanks to Storacha&apos;s content-addressed
+      storage, we we&apos;ll only ever store new data - look ma, no dupes!
+    </ExText>
+  </Explainer>
+)

--- a/src/app/LoggedIn.tsx
+++ b/src/app/LoggedIn.tsx
@@ -10,7 +10,7 @@ import { toast } from 'sonner'
 import { BackupDetail } from '@/components/BackupScreen/BackupDetail'
 import { FullscreenLoader } from '@/components/Loader'
 import StripePricingTable from '@/components/StripePricingTable'
-import { Box, Explainer, ExText, Heading, Stack, Text } from '@/components/ui'
+import { Box, Heading, Stack, Text } from '@/components/ui'
 import { CreateButton } from '@/components/ui/CreateButton'
 import { useBBAnalytics } from '@/hooks/use-bb-analytics'
 import { useMobileScreens } from '@/hooks/use-mobile-screens'
@@ -25,6 +25,7 @@ import { BackupScreen } from '../components/BackupScreen'
 import { useSWR } from '../lib/swr'
 
 import { AppLayout } from './AppLayout'
+import { BackupExplainer } from './BackupExplainer'
 
 let createNewBackup: typeof import('./backups/new/createNewBackup').action
 
@@ -154,30 +155,11 @@ const PricingTableContainer = styled(Stack)`
   padding-top: 2rem;
 `
 
-const BackupExplainer = () => (
-  <Explainer>
-    <ExText>
-      Connect and select a Bluesky account you&apos;d like to start backing up,
-      and then create a Storacha space you&apos;d like to start saving data to.
-    </ExText>
-    <ExText $fontSize="0.875em" $fontWeight="600">
-      Once you create a backup, we&apos;ll make a snapshot of your publicly
-      available Bluesky data - posts, images, videos, follows and followers,
-      blocks, and more - every hour. Thanks to Storacha&apos;s content-addressed
-      storage, we we&apos;ll only ever store new data - look ma, no dupes!
-    </ExText>
-  </Explainer>
-)
-
-const SmallExplainerContainer = styled.div`
+const ExplainerContainer = styled.div`
   margin-top: 3em;
   margin-bottom: 1em;
   padding-bottom: 1.5em;
   border-bottom: 1px solid var(--color-gray-medium);
-`
-
-const BigExplainerContainer = styled.div`
-  margin-top: 1em;
 `
 
 const CreateBackupText = styled(Text)`
@@ -190,6 +172,11 @@ export function LoggedIn() {
   const account = useStorachaAccount()
   const { error: sessionDIDError, mutate } = useSWR(['api', '/session/did'])
   const { logLoginSuccessful } = useBBAnalytics()
+  const { data: backups, isLoading: areBackupsLoading } = useSWR([
+    'api',
+    '/api/backups',
+  ])
+  const areThereBackups = !areBackupsLoading && backups && backups.length > 0
 
   const [sessionCreationAttempted, setSessionCreationAttempted] =
     useState(false)
@@ -226,20 +213,16 @@ export function LoggedIn() {
           <BackupScreen
             selectedBackupId={null}
             rightPanelContent={
-              isSmallViewPort ? (
-                <CreateBackupText>Create a backup above.</CreateBackupText>
-              ) : (
-                <BigExplainerContainer>
-                  <BackupExplainer />
-                </BigExplainerContainer>
-              )
+              <CreateBackupText>
+                Create a backup to see details.
+              </CreateBackupText>
             }
           >
             <Stack>
-              {isSmallViewPort && (
-                <SmallExplainerContainer>
+              {isSmallViewPort && !areThereBackups && (
+                <ExplainerContainer>
                   <BackupExplainer />
-                </SmallExplainerContainer>
+                </ExplainerContainer>
               )}
               <NewBackupForm account={account}>
                 <BackupDetail />

--- a/src/app/Sidebar.tsx
+++ b/src/app/Sidebar.tsx
@@ -6,6 +6,7 @@ import { ArchiveIcon, PauseIcon, XIcon } from '@phosphor-icons/react'
 import { IdentificationBadgeIcon } from '@phosphor-icons/react/dist/ssr'
 import Image from 'next/image'
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 import { css, styled } from 'next-yak'
 
 import { Loader } from '@/components/Loader'
@@ -16,6 +17,7 @@ import { shortenIfOver } from '@/lib/ui'
 import { Backup as BackupType } from '@/types'
 
 import { LogOutButton as BaseLogOutButton } from './authentication'
+import { BackupExplainer } from './BackupExplainer'
 
 const SidebarOutside = styled.nav<{ $variant?: 'desktop' | 'mobile' }>`
   display: flex;
@@ -169,6 +171,7 @@ export function Sidebar({
   selectedBackupId,
   variant = 'desktop',
 }: SidebarProps) {
+  const pathname = usePathname()
   return (
     <SidebarOutside $variant={variant}>
       <Header>
@@ -180,9 +183,9 @@ export function Sidebar({
       <ScrollableContent>
         <div>
           <Heading>Backups</Heading>
-          <Stack $gap="1rem">
+          <Stack $gap="1rem" $mt="1rem">
             <Backups selectedBackupId={selectedBackupId} />
-            <AddBackup href="/">Add backup…</AddBackup>
+            {pathname !== '/' && <AddBackup href="/">Add backup…</AddBackup>}
           </Stack>
         </div>
       </ScrollableContent>
@@ -208,12 +211,12 @@ const BackupsLoader = styled(Loader)`
 `
 
 function Backups({ selectedBackupId }: { selectedBackupId: string | null }) {
-  const { data } = useSWR(['api', '/api/backups'])
-  if (!data) return <BackupsLoader />
-
+  const { data: backups, isLoading } = useSWR(['api', '/api/backups'])
+  if (isLoading) return <BackupsLoader />
+  if (!backups || backups.length === 0) return <BackupExplainer />
   return (
     <BackupList>
-      {data.map((backup) => {
+      {backups.map((backup) => {
         return (
           <Backup
             key={backup.id}

--- a/src/app/backups/[id]/RightSidebarContent.tsx
+++ b/src/app/backups/[id]/RightSidebarContent.tsx
@@ -6,7 +6,7 @@ import { css, styled } from 'next-yak'
 import { ComponentProps } from 'react'
 import { toast } from 'sonner'
 
-import CopyButton from '@/components/CopyButton'
+import { InlineCopyButton } from '@/components/CopyButton'
 import { Loader } from '@/components/Loader'
 import {
   Box,
@@ -46,13 +46,17 @@ const DetailValue = styled.div`
 
 const SnapshotSummary = styled(Box)`
   padding: 1rem;
-  font-size: 0.75rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
 `
 
 const SnapshotLink = styled(Link)`
-  width: 100%;
-  height: 100%;
-  padding: 1rem;
+  display: block;
+  font-family: var(--font-dm-mono);
+  font-size: 1rem;
+  text-align: center;
 `
 
 const SnapshotsLink = styled(Link)`
@@ -79,7 +83,10 @@ export const RightSidebarContent = ({ backup }: { backup: Backup }) => {
         <SubHeading>Details</SubHeading>
         <Stack $direction="row" $alignItems="center" $gap="1rem">
           <DetailName>Account DID</DetailName>
-          <DetailValue>{shortenDID(backup.atprotoAccount)}</DetailValue>
+          <DetailValue>
+            {shortenDID(backup.atprotoAccount)}
+            <InlineCopyButton text={backup.atprotoAccount} size="0.75rem" />
+          </DetailValue>
         </Stack>
         <Stack $direction="row" $gap="1rem">
           <DetailName>Delegation</DetailName>
@@ -88,9 +95,9 @@ export const RightSidebarContent = ({ backup }: { backup: Backup }) => {
           </DetailValue>
         </Stack>
         <Stack $direction="row" $alignItems="center" $gap="1rem">
-          <DetailName>Blobs</DetailName>
+          <DetailName>Media</DetailName>
           <Link href={`/backups/${backup.id}/blobs`}>
-            <DetailValue>View Blobs</DetailValue>
+            <DetailValue>View Media</DetailValue>
           </Link>
         </Stack>
         <Stack $direction="row" $alignItems="center" $gap="1rem">
@@ -131,16 +138,7 @@ export const RightSidebarContent = ({ backup }: { backup: Backup }) => {
                   $background="var(--color-white)"
                 >
                   <SnapshotLink href={`/snapshots/${snapshot.id}`}>
-                    <Stack
-                      $direction="row"
-                      $alignItems="center"
-                      $justifyContent="space-between"
-                      $width="100%"
-                    >
-                      <Stack $direction="column" $alignItems="flex-start">
-                        <h3>{formatDate(snapshot.createdAt)} Snapshot</h3>
-                      </Stack>
-                    </Stack>
+                    {formatDate(snapshot.createdAt)}
                   </SnapshotLink>
                 </SnapshotSummary>
               ))}
@@ -188,7 +186,7 @@ const DelegationDetail = ({ backup }: { backup: Backup }) => {
           <span title={backup.delegationCid}>
             {shortenCID(backup.delegationCid)}
           </span>
-          <CopyButton text={backup.delegationCid} size="0.75rem" />
+          <InlineCopyButton text={backup.delegationCid} />
           {isLoading && <Spinner size="xs" />}
         </Stack>
       )}

--- a/src/app/backups/[id]/snapshots/SnapshotPage.tsx
+++ b/src/app/backups/[id]/snapshots/SnapshotPage.tsx
@@ -20,13 +20,17 @@ const SnapshotContainer = styled(Stack)`
 
 const SnapshotSummary = styled(Box)`
   padding: 1rem;
-  font-size: 0.75rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
 `
 
 const SnapshotLink = styled(Link)`
-  width: 100%;
-  height: 100%;
-  padding: 1rem;
+  display: block;
+  font-family: var(--font-dm-mono);
+  font-size: 1rem;
+  text-align: center;
 `
 
 interface SnapshotPageProps {
@@ -51,16 +55,7 @@ function Snapshots({ snapshots, loading, backupId }: SnapshotPageProps) {
           {snapshots?.map((snapshot) => (
             <SnapshotSummary key={snapshot.id} $background="var(--color-white)">
               <SnapshotLink href={`/snapshots/${snapshot.id}`}>
-                <Stack
-                  $direction="row"
-                  $alignItems="center"
-                  $justifyContent="space-between"
-                  $width="100%"
-                >
-                  <Stack $direction="column" $alignItems="flex-start">
-                    <h3>{formatDate(snapshot.createdAt)} Snapshot</h3>
-                  </Stack>
-                </Stack>
+                {formatDate(snapshot.createdAt)}
               </SnapshotLink>
             </SnapshotSummary>
           ))}

--- a/src/components/BackupScreen/BackupDetail.tsx
+++ b/src/components/BackupScreen/BackupDetail.tsx
@@ -236,8 +236,8 @@ export const BackupDetail = ({ backup }: BackupProps) => {
         <BackupNameInput
           type="text"
           name="name"
-          placeholder="New Backup"
-          defaultValue="New Backup"
+          placeholder="My Bluesky Backup"
+          defaultValue="My Bluesky Backup"
           required
         />
       )}

--- a/src/components/Blobs.tsx
+++ b/src/components/Blobs.tsx
@@ -10,6 +10,7 @@ import { shortenCID } from '@/lib/ui'
 import { ATBlob } from '@/types'
 
 import { BackButton } from './BackButton'
+import { InlineCopyButton } from './CopyButton'
 import { Loader } from './Loader'
 import { Box, Heading, Stack, Text } from './ui'
 
@@ -39,7 +40,7 @@ export const Blobs = ({ blobs, backPath, loading, location }: BlobProps) => {
         <Stack $gap="1rem">
           <Stack $direction="row" $gap="1rem">
             <BackButton path={backPath} />
-            <Heading>Blobs in this {location}</Heading>
+            <Heading>Media in this {location}</Heading>
           </Stack>
           <Stack
             $direction="row"
@@ -69,6 +70,7 @@ export const Blobs = ({ blobs, backPath, loading, location }: BlobProps) => {
                       $color="var(--color-black)"
                     >
                       {shortenCID(blob.cid)}
+                      <InlineCopyButton text={blob.cid} />
                     </Text>
                   </Stack>
                   <Text $fontSize="0.6235rem">{blob.createdAt}</Text>

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { CheckFatIcon, CopyIcon, IconProps } from '@phosphor-icons/react'
+import { styled } from 'next-yak'
 import { useEffect, useState } from 'react'
 
 import { IconButton } from './ui'
@@ -36,3 +37,15 @@ export default function CopyButton({ text, size = '16' }: CopyButtonProps) {
     </IconButton>
   )
 }
+
+const InlineCopyButtonContainer = styled.div`
+  display: inline-block;
+  margin-left: 0.25em;
+  margin-right: 0.25em;
+`
+
+export const InlineCopyButton = (props: CopyButtonProps) => (
+  <InlineCopyButtonContainer>
+    <CopyButton {...props} size="0.75rem" />
+  </InlineCopyButtonContainer>
+)

--- a/src/components/RestoreUI/RestoreDialogView.tsx
+++ b/src/components/RestoreUI/RestoreDialogView.tsx
@@ -201,7 +201,7 @@ export function RestoreDialogView({
                 $left="1rem"
                 $right="1rem"
               >
-                <DataTypeHeading>Blobs</DataTypeHeading>
+                <DataTypeHeading>Media</DataTypeHeading>
                 <StorachaElement>
                   <DataSourceIcon>{blobs?.length || '0'}</DataSourceIcon>
                 </StorachaElement>

--- a/src/components/SnapshotScreen/SnapshotDetail.tsx
+++ b/src/components/SnapshotScreen/SnapshotDetail.tsx
@@ -5,7 +5,7 @@ import { cidUrl } from '@/lib/storacha'
 import { formatDate, shortenDID } from '@/lib/ui'
 import { Snapshot } from '@/types'
 
-import CopyButton from '../CopyButton'
+import { InlineCopyButton } from '../CopyButton'
 import { Heading, Stack, SubHeading } from '../ui'
 
 const Details = styled(Stack)``
@@ -32,7 +32,7 @@ export default function SnapshotDetail({ snapshot }: SnapshotDetailArgs) {
         <DetailName>Account DID</DetailName>
         <DetailValue>
           {shortenDID(snapshot.atprotoAccount)}
-          <CopyButton text={snapshot.atprotoAccount} />
+          <InlineCopyButton text={snapshot.atprotoAccount} />
         </DetailValue>
       </Stack>
       <Stack $direction="row" $alignItems="center" $gap="1rem">
@@ -58,9 +58,9 @@ export default function SnapshotDetail({ snapshot }: SnapshotDetailArgs) {
         </Stack>
       )}
       <Stack $direction="row" $alignItems="center" $gap="1rem">
-        <DetailName>Blobs</DetailName>
+        <DetailName>Media</DetailName>
         <Link href={`/snapshots/${snapshot.id}/blobs`}>
-          <DetailValue>View Blobs</DetailValue>
+          <DetailValue>View Media</DetailValue>
         </Link>
       </Stack>
     </Details>

--- a/src/components/ui/text.tsx
+++ b/src/components/ui/text.tsx
@@ -67,5 +67,5 @@ export const Explainer = styled(Stack)`
 
 export const ExText = styled(Text)`
   font-size: 0.875em;
-  font-weight: 600;
+  font-weight: 400;
 `


### PR DESCRIPTION
Respond to feedback in #205 thanks @alanshaw! I think I got to most of your feedback - much of it was obviated by earlier changes, and a couple things are slightly bigger projects, but I think this is good stuff all around:

* move "backup explainer" to a more sensible place (the "empty backups list" space on desktop and above the backup creation form if no backups on mobile)
* don't show "add backup" in the left sidebar if we're on the backup creation page
* clean up snapshot list items in the sidebar and on the snapshots page
* sprinkle on some more copy buttons next to shortened strings
* default backup name to "My Bluesky Backup"
* rename "blobs" "media" in a bunch of places in the UI