### PR TITLE
fix(deploy): remove staging replication

### DIFF
--- a/deploy/app/main.tf
+++ b/deploy/app/main.tf
@@ -52,7 +52,7 @@ resource "random_password" "session_password" {
 
 
 module "app" {
-  source = "github.com/storacha/storoku//app?ref=v0.2.40"
+  source = "github.com/storacha/storoku//app?ref=v0.2.41"
   private_key = var.private_key
   private_key_env_var = "SERVER_IDENTITY_PRIVATE_KEY"
   httpport = 3000

--- a/deploy/shared/main.tf
+++ b/deploy/shared/main.tf
@@ -33,7 +33,7 @@ provider "aws" {
 }
 
 module "shared" {
-  source = "github.com/storacha/storoku//shared?ref=v0.2.40"
+  source = "github.com/storacha/storoku//shared?ref=v0.2.41"
   create_db = true
   caches = [  ]
   app = var.app


### PR DESCRIPTION
# Goals

Fix staging deploys

# Implementation

Bluesky and telegram were over writing each other unfortunately for the staging replication, which turns out to be a singleton-per-region object. so it's configured manually for now.

update storoku, which leaves replication to be configed manually