### PR TITLE
fix: Align data boxes correctly

### DIFF
--- a/src/components/BackupScreen/DataBox.tsx
+++ b/src/components/BackupScreen/DataBox.tsx
@@ -17,6 +17,9 @@ interface DataBoxProps extends SwitchProps {
 
 const Label = styled.label`
   display: contents;
+  & > * {
+    flex: 1;
+  }
 `
 
 export const DataBox = ({


### PR DESCRIPTION
This has been bugging me. It should look a lot more polished this way.




#### PR Dependency Tree


* **PR #226** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)