### PR TITLE
fix: unauthorized error after clicking back on snapshot blobs

### DIFF
--- a/src/app/snapshots/[id]/blobs/BlobsPage.tsx
+++ b/src/app/snapshots/[id]/blobs/BlobsPage.tsx
@@ -37,7 +37,7 @@ export default function BlobsPage({ id }: { id: string }) {
       <Stack $gap="0.8rem">
         <Blobs
           blobs={paginatedBlobs?.results}
-          backPath={`/backups/${id}`}
+          backPath={`/snapshots/${id}`}
           loading={isLoading}
           location="Snapshot"
         />


### PR DESCRIPTION
it was just sending people to the wrong place