### PR TITLE
fix: dont fetch `/api/keys` without auth

### DIFF
--- a/src/contexts/keychain.tsx
+++ b/src/contexts/keychain.tsx
@@ -80,7 +80,9 @@ export const KeychainProvider = ({
   const [selectedKey, setSelectedKey] = useState<RotationKey>()
   const [isDeletingKey, setIsDeletingKey] = useState(false)
   const storachaAccount = useStorachaAccount()
-  const { data: keys, mutate: mutateKeys } = useSWR(['api', `/api/keys`])
+  const { data: keys, mutate: mutateKeys } = useSWR(
+    storachaAccount ? ['api', `/api/keys`] : null
+  )
   async function generateKeyPair(atprotoAccount: string) {
     if (storachaAccount) {
       const keypair = await Secp256k1Keypair.create({ exportable: true })


### PR DESCRIPTION
fixes `/api/key` being fetched before an account has been authenticated.

context: https://bsky.app/profile/trav.page/post/3lrl36uftlc2i
docs: https://swr.vercel.app/docs/conditional-fetching