### PR TITLE
fix: dynamically import createSnapshot

### DIFF
--- a/src/app/backups/[id]/CreateSnapshotButton.tsx
+++ b/src/app/backups/[id]/CreateSnapshotButton.tsx
@@ -1,35 +1,38 @@
 'use client'
 
 import { useAuthenticator } from '@storacha/ui-react'
+import { useEffect, useState } from 'react'
 
 import { CreateButton } from '@/components/ui/CreateButton'
 import { delegate } from '@/lib/delegate'
 import { useSWRMutation } from '@/lib/swr'
 import { Backup } from '@/types'
 
-let createSnapshot: typeof import('./createSnapshot').createSnapshot
-
-if (process.env.STORYBOOK) {
-  createSnapshot = () => {
-    throw new Error('Server Functions are not available in Storybook')
-  }
-} else {
-  createSnapshot = (await import('./createSnapshot')).createSnapshot
-}
-
 export const CreateSnapshotButton = ({ backup }: { backup: Backup }) => {
   const [{ accounts, client }] = useAuthenticator()
   const account = accounts[0]
+  const [createSnapshot, setCreateSnapshot] = useState<
+    typeof import('./createSnapshot').createSnapshot | null
+  >(null)
+
+  useEffect(() => {
+    if (process.env.STORYBOOK) {
+      return
+    }
+
+    const importCreateSnapshot = async () => {
+      const { createSnapshot } = await import('./createSnapshot')
+      setCreateSnapshot(createSnapshot)
+    }
+    importCreateSnapshot()
+  }, [])
 
   const enabled = client && backup
   const { trigger, isMutating } = useSWRMutation(
     enabled && ['api', `/api/backups/${backup.id}/snapshots`],
     async () => {
-      // SWR guarantees this won't actually happen.
-      if (!enabled)
-        throw new Error('Mutation ran but key should have been null')
-      const delegationData = await delegate(client, backup.storachaSpace)
-      await createSnapshot({ backupId: backup.id, delegationData })
+      const delegationData = await delegate(client!, backup.storachaSpace)
+      await createSnapshot?.({ backupId: backup.id, delegationData })
     }
   )
 


### PR DESCRIPTION
removes the need for a top level await. havent tested this but it's how we do things at work to avoid the same issue.

context:
this was output in the build step. https://github.com/storacha/bluesky-backup-webapp-server/actions/runs/15652700627/job/44099633926

> `./src/app/backups/[id]/CreateSnapshotButton.tsx`
> The generated code contains 'async/await' because this module is using "topLevelAwait".
> However, your target environment does not appear to support 'async/await'.
> As a result, the code may not run as expected or may cause runtime errors.