### PR TITLE
feat: send analytics when someone starts the Humanode or plan selection processes

### DIFF
--- a/src/components/HumanodeAuthLink.tsx
+++ b/src/components/HumanodeAuthLink.tsx
@@ -5,6 +5,8 @@ import { base64url } from 'multiformats/bases/base64'
 import { styled } from 'next-yak'
 import { useEffect, useState } from 'react'
 
+import { useBBAnalytics } from '@/hooks/use-bb-analytics'
+import { useStorachaAccount } from '@/hooks/use-plan'
 import {
   HUMANODE_AUTH_URL,
   HUMANODE_CLIENT_ID,
@@ -21,8 +23,8 @@ const HumanodeLink = styled.a`
 `
 
 export default function HumanodeAuthLink() {
-  const [{ accounts, client }] = useW3()
-  const account = accounts[0]
+  const [{ client }] = useW3()
+  const account = useStorachaAccount()
   const [state, setState] = useState<string>()
 
   useEffect(
@@ -59,8 +61,16 @@ export default function HumanodeAuthLink() {
     [client, account]
   )
   const humanodeHref = `${HUMANODE_AUTH_URL}?response_type=code&client_id=${HUMANODE_CLIENT_ID}&redirect_uri=${HUMANODE_OAUTH_CALLBACK_URL}&scope=openid&state=${state}`
+  const { logHumanodeStarted } = useBBAnalytics()
   return (
-    <HumanodeLink href={humanodeHref} target="_blank" rel="noopener noreferrer">
+    <HumanodeLink
+      href={humanodeHref}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={() => {
+        logHumanodeStarted({ userId: account?.did() })
+      }}
+    >
       Give me a free plan!
     </HumanodeLink>
   )

--- a/src/components/PlanSelector.tsx
+++ b/src/components/PlanSelector.tsx
@@ -5,7 +5,9 @@ import { useState } from 'react'
 import HumanodeAuthLink from '@/components/HumanodeAuthLink'
 import StripePricingTable from '@/components/StripePricingTable'
 import { Box, Button, Heading, Stack, Text } from '@/components/ui'
+import { useBBAnalytics } from '@/hooks/use-bb-analytics'
 import { useMobileScreens } from '@/hooks/use-mobile-screens'
+import { useStorachaAccount } from '@/hooks/use-plan'
 
 const PricingTableContainer = styled(Stack)`
   width: 100%;
@@ -15,7 +17,8 @@ const PricingTableContainer = styled(Stack)`
 export default function PlanSelector() {
   const [stripeSignup, setStripeSignup] = useState(false)
   const { isMobile } = useMobileScreens()
-
+  const { logPlanSelection } = useBBAnalytics()
+  const account = useStorachaAccount()
   return (
     <PricingTableContainer $alignItems="center" $gap="1rem">
       <Heading>Please Sign Up for a Storacha Storage Plan</Heading>
@@ -47,6 +50,7 @@ export default function PlanSelector() {
           <HumanodeAuthLink />
           <Button
             onClick={() => {
+              logPlanSelection({ userId: account?.did() })
               setStripeSignup(true)
             }}
           >

--- a/src/hooks/use-bb-analytics.ts
+++ b/src/hooks/use-bb-analytics.ts
@@ -105,6 +105,15 @@ export const useBBAnalytics = () => {
     [plausible, utmParams]
   )
 
+  const logHumanodeStarted = useCallback(
+    (props: BBEvents['humanode-started']) => {
+      plausible('humanode-started', {
+        props: { ...utmParams, ...props },
+      })
+    },
+    [plausible, utmParams]
+  )
+
   return {
     logPlanSelection,
     logBackupCreationStarted,
@@ -113,5 +122,6 @@ export const useBBAnalytics = () => {
     logBlueskyLoginSuccessful,
     logLoginStarted,
     logLoginSuccessful,
+    logHumanodeStarted,
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -290,4 +290,7 @@ export type BBEvents = {
   }
   'create-backup-started': BackupEventParams
   'create-backup-success': BackupEventParams
+  'humanode-started': TrackingParams & {
+    userId?: AccountDid
+  }
 }


### PR DESCRIPTION
we can't track the end of these processes for now because they end elsewhere, but there are potentially ways to work around that in both cases later